### PR TITLE
Feature/additional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ This is your configuration object for the client
 - **issuer**: (`string`) *REQUIRED* the url of the auth server
 - **clientId**: (`string`) *REQUIRED* your client id on the auth server
 - **redirectUrl**: (`string`) *REQUIRED* the url that links back to your app with the auth code
-- **additionalParameters**: (`object` | `null`) additional parameters that will be passed in the authorization request
+- **additionalParameters**: (`object` | `null`) additional parameters that will be passed in the authorization request.
+Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
+`hello=world&foo=bar` to the authorization request.
 
 ### `refresh`
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ const result = await appAuth.authorize(scopes);
 // returns accessToken, accessTokenExpirationDate and refreshToken
 ```
 
-## config
+#### config
 
 This is your configuration object for the client
 - **issuer**: (`string`) *REQUIRED* the url of the auth server

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ const result = await appAuth.authorize(scopes);
 // returns accessToken, accessTokenExpirationDate and refreshToken
 ```
 
+## config
+
+This is your configuration object for the client
+- **issuer**: (`string`) *REQUIRED* the url of the auth server
+- **clientId**: (`string`) *REQUIRED* your client id on the auth server
+- **redirectUrl**: (`string`) *REQUIRED* the url that links back to your app with the auth code
+- **additionalParameters**: (`object` | `null`) additional parameters that will be passed in the authorization request
+
 ### `refresh`
 
 This method will refresh the accessToken using the refreshToken. Some auth providers will also give
@@ -280,7 +288,7 @@ import AppAuth from 'react-native-app-auth';
 // initialise the client with your configuration
 const appAuth = new AppAuth({
   issuer: '<YOUR_ISSUER_URL>',
-  clientId: '<YOUR_CLIENT_ID',
+  clientId: '<YOUR_CLIENT_ID>',
   redirectUrl: '<YOUR_REDIRECT_URL>',
 });
 

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -72,7 +72,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         ReadableMapKeySetIterator iterator = additionalParameters.keySetIterator();
 
-        if (iterator.hasNextKey()) {
+        while (iterator.hasNextKey()) {
             String nextKey = iterator.nextKey();
             additionalParametersHash.put(nextKey, additionalParameters.getString(nextKey));
         }

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ export default class AppAuth {
       this.config.issuer,
       this.config.redirectUrl,
       this.config.clientId,
-      scopes
+      scopes,
+      this.config.additionalParameters
     );
   }
 
@@ -36,7 +37,8 @@ export default class AppAuth {
       this.config.redirectUrl,
       this.config.clientId,
       refreshToken,
-      scopes
+      scopes,
+      this.config.additionalParameters
     );
   }
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -17,6 +17,7 @@ describe('AppAuth', () => {
     issuer: 'test-issuer',
     redirectUrl: 'test-redirectUrl',
     clientId: 'test-clientId',
+    additionalParameters: { hello: 'world' },
   };
 
   beforeAll(() => {
@@ -31,6 +32,11 @@ describe('AppAuth', () => {
     it('saves the config correctly', () => {
       const appAuth = new AppAuth(config);
       expect(appAuth.getConfig()).toEqual(config);
+    });
+
+    it('saves the additionalParameters correctly if they are empty', () => {
+      const appAuth = new AppAuth({ ...config, additionalParameters: undefined });
+      expect(appAuth.getConfig()).toEqual({ ...config, additionalParameters: undefined });
     });
 
     it('throws an error when issuer is not a string', () => {
@@ -81,7 +87,8 @@ describe('AppAuth', () => {
         config.issuer,
         config.redirectUrl,
         config.clientId,
-        scopes
+        scopes,
+        config.additionalParameters
       );
     });
   });
@@ -124,7 +131,8 @@ describe('AppAuth', () => {
         config.redirectUrl,
         config.clientId,
         refreshToken,
-        scopes
+        scopes,
+        config.additionalParameters
       );
     });
   });

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -18,6 +18,7 @@ RCT_REMAP_METHOD(authorize,
                  redirectUrl: (NSString *) redirectUrl
                  clientId: (NSString *) clientId
                  scopes: (NSArray *) scopes
+                 additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  resolve:(RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
@@ -35,7 +36,7 @@ RCT_REMAP_METHOD(authorize,
                                                                                                         scopes:scopes
                                                                                                    redirectURL:[NSURL URLWithString:redirectUrl]
                                                                                                   responseType:OIDResponseTypeCode
-                                                                                          additionalParameters:nil];
+                                                                                          additionalParameters:additionalParameters];
 
 
                                                         // performs authentication request
@@ -79,6 +80,7 @@ RCT_REMAP_METHOD(refresh,
                  clientId: (NSString *) clientId
                  refreshToken: (NSString *) refreshToken
                  scopes: (NSArray *) scopes
+                 additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  resolve:(RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
@@ -99,7 +101,7 @@ RCT_REMAP_METHOD(refresh,
                                                                                                 scopes:scopes
                                                                                           refreshToken:refreshToken
                                                                                           codeVerifier:nil
-                                                                                  additionalParameters:nil];
+                                                                                  additionalParameters:additionalParameters];
 
                                                         [OIDAuthorizationService performTokenRequest:tokenRefreshRequest
                                                                                             callback:^(OIDTokenResponse *_Nullable response,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4076,7 +4076,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.10.2:
+prettier@1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
 


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/30

This will enable passing additional parameters to the auth server in the auth request.
They will be passed into the auth object in JavaScript

e.g.

```js
const appAuth = new AppAuth({
  issuer: '<YOUR_ISSUER_URL>',
  clientId: '<YOUR_CLIENT_ID>',
  redirectUrl: '<YOUR_REDIRECT_URL>',
  additionalParameters: { hello: 'world' },
});
```

- [x] implement `additionalParameters` on iOS
- [x] implement `additionalParameters` on Android
- [x] add documentation for the `config` object