### PR TITLE
Allow insecure HTTP requests on Android

### DIFF
--- a/Example/ios/AppAuthExample/Info.plist
+++ b/Example/ios/AppAuthExample/Info.plist
@@ -39,6 +39,11 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>demo.identityserver.io</key>
+			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 			<key>localhost</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ with optional overrides.
 * **additionalParameters** - (`object`) additional parameters that will be passed in the authorization request.
   Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
   `hello=world&foo=bar` to the authorization request.
-* **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. :warning: Can be useful for testing against local server, _should not be used in production._
+* :warning: **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. Can be useful for testing against local server, _should not be used in production._ This setting has no effect on iOS; to enable insecure HTTP requests, add a [NSExceptionAllowsInsecureHTTPLoads exception](https://cocoacasts.com/how-to-add-app-transport-security-exception-domains) to your App Transport Security settings.
 
 #### result
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ with optional overrides.
 * **additionalParameters** - (`object`) additional parameters that will be passed in the authorization request.
   Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
   `hello=world&foo=bar` to the authorization request.
+* **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. :warning: Can be useful for testing against local server, _should not be used in production._
 
 #### result
 

--- a/android/src/main/java/com/reactlibrary/ConnectionBuilderForTesting.java
+++ b/android/src/main/java/com/reactlibrary/ConnectionBuilderForTesting.java
@@ -1,0 +1,128 @@
+package com.reactlibrary;
+
+/*
+ * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+import android.annotation.SuppressLint;
+import android.net.Uri;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import net.openid.appauth.Preconditions;
+import net.openid.appauth.connectivity.ConnectionBuilder;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * An implementation of {@link ConnectionBuilder} that permits connecting to http
+ * links, and ignores certificates for https connections. *THIS SHOULD NOT BE USED IN PRODUCTION
+ * CODE*. It is intended to facilitate easier testing of AppAuth against development servers
+ * only.
+ */
+public final class ConnectionBuilderForTesting implements ConnectionBuilder {
+
+    public static final ConnectionBuilderForTesting INSTANCE = new ConnectionBuilderForTesting();
+
+    private static final String TAG = "ConnBuilder";
+
+    private static final int CONNECTION_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(15);
+    private static final int READ_TIMEOUT_MS = (int) TimeUnit.SECONDS.toMillis(10);
+
+    private static final String HTTP = "http";
+    private static final String HTTPS = "https";
+
+    @SuppressLint("TrustAllX509TrustManager")
+    private static final TrustManager[] ANY_CERT_MANAGER = new TrustManager[] {
+            new X509TrustManager() {
+                public X509Certificate[] getAcceptedIssuers() {
+                    return null;
+                }
+
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+            }
+    };
+
+    @SuppressLint("BadHostnameVerifier")
+    private static final HostnameVerifier ANY_HOSTNAME_VERIFIER = new HostnameVerifier() {
+        public boolean verify(String hostname, SSLSession session) {
+            return true;
+        }
+    };
+
+    @Nullable
+    private static final SSLContext TRUSTING_CONTEXT;
+
+    static {
+        SSLContext context;
+        try {
+            context = SSLContext.getInstance("SSL");
+        } catch (NoSuchAlgorithmException e) {
+            Log.e("ConnBuilder", "Unable to acquire SSL context");
+            context = null;
+        }
+
+        SSLContext initializedContext = null;
+        if (context != null) {
+            try {
+                context.init(null, ANY_CERT_MANAGER, new java.security.SecureRandom());
+                initializedContext = context;
+            } catch (KeyManagementException e) {
+                Log.e(TAG, "Failed to initialize trusting SSL context");
+            }
+        }
+
+        TRUSTING_CONTEXT = initializedContext;
+    }
+
+    private ConnectionBuilderForTesting() {
+        // no need to construct new instances
+    }
+
+    @NonNull
+    @Override
+    public HttpURLConnection openConnection(@NonNull Uri uri) throws IOException {
+        Preconditions.checkNotNull(uri, "url must not be null");
+        Preconditions.checkArgument(HTTP.equals(uri.getScheme()) || HTTPS.equals(uri.getScheme()),
+                "scheme or uri must be http or https");
+        HttpURLConnection conn = (HttpURLConnection) new URL(uri.toString()).openConnection();
+        conn.setConnectTimeout(CONNECTION_TIMEOUT_MS);
+        conn.setReadTimeout(READ_TIMEOUT_MS);
+        conn.setInstanceFollowRedirects(false);
+
+        if (conn instanceof HttpsURLConnection && TRUSTING_CONTEXT != null) {
+            HttpsURLConnection httpsConn = (HttpsURLConnection) conn;
+            httpsConn.setSSLSocketFactory(TRUSTING_CONTEXT.getSocketFactory());
+            httpsConn.setHostnameVerifier(ANY_HOSTNAME_VERIFIER);
+        }
+
+        return conn;
+    }
+}

--- a/android/src/main/java/com/reactlibrary/utils/UnsafeConnectionBuilder.java
+++ b/android/src/main/java/com/reactlibrary/utils/UnsafeConnectionBuilder.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.reactlibrary.utils;
 
 /*
  * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.
@@ -45,9 +45,9 @@ import javax.net.ssl.X509TrustManager;
  * CODE*. It is intended to facilitate easier testing of AppAuth against development servers
  * only.
  */
-public final class ConnectionBuilderForTesting implements ConnectionBuilder {
+public final class UnsafeConnectionBuilder implements ConnectionBuilder {
 
-    public static final ConnectionBuilderForTesting INSTANCE = new ConnectionBuilderForTesting();
+    public static final UnsafeConnectionBuilder INSTANCE = new UnsafeConnectionBuilder();
 
     private static final String TAG = "ConnBuilder";
 
@@ -102,7 +102,7 @@ public final class ConnectionBuilderForTesting implements ConnectionBuilder {
         TRUSTING_CONTEXT = initializedContext;
     }
 
-    private ConnectionBuilderForTesting() {
+    private UnsafeConnectionBuilder() {
         // no need to construct new instances
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ export interface AuthConfiguration extends BaseAuthConfiguration {
   scopes: string[];
   redirectUrl: string;
   additionalParameters?: { [name: string]: string };
+  dangerouslyAllowInsecureHttpRequests?: boolean;
 }
 
 export interface RevokeConfiguration {

--- a/index.js
+++ b/index.js
@@ -12,18 +12,25 @@ const validateClientId = clientId =>
 const validateRedirectUrl = redirectUrl =>
   invariant(typeof redirectUrl === 'string', 'Config error: redirectUrl must be a string');
 
-export const authorize = ({ issuer, redirectUrl, clientId, scopes, additionalParameters }) => {
+export const authorize = ({ issuer, redirectUrl, clientId, scopes, additionalParameters, dangerouslyAllowInsecureHttpRequests = false }) => {
   validateScopes(scopes);
   validateIssuer(issuer);
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
   // TODO: validateAdditionalParameters
 
-  return RNAppAuth.authorize(issuer, redirectUrl, clientId, scopes, additionalParameters);
+  return RNAppAuth.authorize(
+    issuer,
+    redirectUrl,
+    clientId,
+    scopes,
+    additionalParameters,
+    dangerouslyAllowInsecureHttpRequests
+  );
 };
 
 export const refresh = (
-  { issuer, redirectUrl, clientId, scopes, additionalParameters },
+  { issuer, redirectUrl, clientId, scopes, additionalParameters, dangerouslyAllowInsecureHttpRequests = false },
   { refreshToken }
 ) => {
   validateScopes(scopes);
@@ -39,7 +46,8 @@ export const refresh = (
     clientId,
     refreshToken,
     scopes,
-    additionalParameters
+    additionalParameters,
+    dangerouslyAllowInsecureHttpRequests
   );
 };
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 import invariant from 'invariant';
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 
 const { RNAppAuth } = NativeModules;
 
@@ -19,14 +19,18 @@ export const authorize = ({ issuer, redirectUrl, clientId, scopes, additionalPar
   validateRedirectUrl(redirectUrl);
   // TODO: validateAdditionalParameters
 
-  return RNAppAuth.authorize(
+  const nativeMethodArguments = [
     issuer,
     redirectUrl,
     clientId,
     scopes,
-    additionalParameters,
-    dangerouslyAllowInsecureHttpRequests
-  );
+    additionalParameters
+  ]
+  if (Platform.OS === 'android') {
+    nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
+  }
+
+  return RNAppAuth.authorize(...nativeMethodArguments);
 };
 
 export const refresh = (
@@ -40,15 +44,20 @@ export const refresh = (
   invariant(refreshToken, 'Please pass in a refresh token');
   // TODO: validateAdditionalParameters
 
-  return RNAppAuth.refresh(
+  const nativeMethodArguments = [
     issuer,
     redirectUrl,
     clientId,
     refreshToken,
     scopes,
-    additionalParameters,
-    dangerouslyAllowInsecureHttpRequests
-  );
+    additionalParameters
+  ];
+
+  if (Platform.OS === 'android') {
+    nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
+  }
+
+  return RNAppAuth.refresh(...nativeMethodArguments);
 };
 
 export const revoke = async ({ clientId, issuer }, { tokenToRevoke, sendClientId = false }) => {

--- a/index.js
+++ b/index.js
@@ -12,20 +12,21 @@ const validateClientId = clientId =>
 const validateRedirectUrl = redirectUrl =>
   invariant(typeof redirectUrl === 'string', 'Config error: redirectUrl must be a string');
 
-export const authorize = ({ issuer, redirectUrl, clientId, scopes, additionalParameters, dangerouslyAllowInsecureHttpRequests = false }) => {
+export const authorize = ({
+  issuer,
+  redirectUrl,
+  clientId,
+  scopes,
+  additionalParameters,
+  dangerouslyAllowInsecureHttpRequests = false,
+}) => {
   validateScopes(scopes);
   validateIssuer(issuer);
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
   // TODO: validateAdditionalParameters
 
-  const nativeMethodArguments = [
-    issuer,
-    redirectUrl,
-    clientId,
-    scopes,
-    additionalParameters
-  ]
+  const nativeMethodArguments = [issuer, redirectUrl, clientId, scopes, additionalParameters];
   if (Platform.OS === 'android') {
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
   }
@@ -34,7 +35,14 @@ export const authorize = ({ issuer, redirectUrl, clientId, scopes, additionalPar
 };
 
 export const refresh = (
-  { issuer, redirectUrl, clientId, scopes, additionalParameters, dangerouslyAllowInsecureHttpRequests = false },
+  {
+    issuer,
+    redirectUrl,
+    clientId,
+    scopes,
+    additionalParameters,
+    dangerouslyAllowInsecureHttpRequests = false,
+  },
   { refreshToken }
 ) => {
   validateScopes(scopes);
@@ -50,7 +58,7 @@ export const refresh = (
     clientId,
     refreshToken,
     scopes,
-    additionalParameters
+    additionalParameters,
   ];
 
   if (Platform.OS === 'android') {

--- a/index.spec.js
+++ b/index.spec.js
@@ -7,6 +7,9 @@ jest.mock('react-native', () => ({
       refresh: jest.fn(),
     },
   },
+  Platform: {
+    OS: 'ios',
+  },
 }));
 
 describe('AppAuth', () => {
@@ -65,7 +68,7 @@ describe('AppAuth', () => {
       }).toThrow('Scope error: please add at least one scope');
     });
 
-    it('calls the native wrapper with the correct args', () => {
+    it('calls the native wrapper with the correct args on iOS', () => {
       authorize(config);
       expect(mockAuthorize).toHaveBeenCalledWith(
         config.issuer,
@@ -74,6 +77,52 @@ describe('AppAuth', () => {
         config.scopes,
         config.additionalParameters
       );
+    });
+
+    describe('Android-specific dangerouslyAllowInsecureHttpRequests parameter', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'android';
+      });
+
+      afterEach(() => {
+        require('react-native').Platform.OS = 'ios';
+      });
+
+      it('calls the native wrapper with default value `false`', () => {
+        authorize(config);
+        expect(mockAuthorize).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          config.scopes,
+          config.additionalParameters,
+          false
+        );
+      });
+
+      it('calls the native wrapper with passed value `false`', () => {
+        authorize({ ...config, dangerouslyAllowInsecureHttpRequests: false });
+        expect(mockAuthorize).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          config.scopes,
+          config.additionalParameters,
+          false
+        );
+      });
+
+      it('calls the native wrapper with passed value `true`', () => {
+        authorize({ ...config, dangerouslyAllowInsecureHttpRequests: true });
+        expect(mockAuthorize).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          config.scopes,
+          config.additionalParameters,
+          true
+        );
+      });
     });
   });
 
@@ -119,7 +168,7 @@ describe('AppAuth', () => {
       }).toThrow('Scope error: please add at least one scope');
     });
 
-    it('calls the native wrapper with the correct args', () => {
+    it('calls the native wrapper with the correct args on iOS', () => {
       refresh({ ...config }, { refreshToken: 'such-token' });
       expect(mockRefresh).toHaveBeenCalledWith(
         config.issuer,
@@ -129,6 +178,61 @@ describe('AppAuth', () => {
         config.scopes,
         config.additionalParameters
       );
+    });
+
+    describe('Android-specific dangerouslyAllowInsecureHttpRequests parameter', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'android';
+      });
+
+      afterEach(() => {
+        require('react-native').Platform.OS = 'ios';
+      });
+
+      it('calls the native wrapper with default value `false`', () => {
+        refresh(config, { refreshToken: 'such-token' });
+        expect(mockRefresh).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          'such-token',
+          config.scopes,
+          config.additionalParameters,
+          false
+        );
+      });
+
+      it('calls the native wrapper with passed value `false`', () => {
+        refresh(
+          { ...config, dangerouslyAllowInsecureHttpRequests: false },
+          { refreshToken: 'such-token' }
+        );
+        expect(mockRefresh).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          'such-token',
+          config.scopes,
+          config.additionalParameters,
+          false
+        );
+      });
+
+      it('calls the native wrapper with passed value `true`', () => {
+        refresh(
+          { ...config, dangerouslyAllowInsecureHttpRequests: true },
+          { refreshToken: 'such-token' }
+        );
+        expect(mockRefresh).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          'such-token',
+          config.scopes,
+          config.additionalParameters,
+          true
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Adds a new optional `dangerouslyAllowInsecureHttpRequests` flag that allows connecting to plain HTTP resources and HTTPS resources with self-signed or invalid certificates.

Fixes #45.
