### PR TITLE
Support manual service configuration

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -18,7 +18,11 @@ const config = {
   clientId: 'native.code',
   redirectUrl: 'io.identityserver.demo:/oauthredirect',
   additionalParameters: {},
-  scopes: ['openid', 'profile', 'email', 'offline_access']
+  scopes: ['openid', 'profile', 'email', 'offline_access'],
+  serviceConfiguration: {
+    authorizationEndpoint: 'https://demo.identityserver.io/connect/authorize',
+    tokenEndpoint: 'https://demo.identityserver.io/connect/token'
+  }
 };
 
 export default class App extends Component<{}, State> {
@@ -41,7 +45,7 @@ export default class App extends Component<{}, State> {
   authorize = async () => {
     try {
       const authState = await authorize(config);
-      
+
       this.animateState(
         {
           hasLoggedInOnce: true,

--- a/Example/App.js
+++ b/Example/App.js
@@ -18,11 +18,13 @@ const config = {
   clientId: 'native.code',
   redirectUrl: 'io.identityserver.demo:/oauthredirect',
   additionalParameters: {},
-  scopes: ['openid', 'profile', 'email', 'offline_access'],
-  serviceConfiguration: {
-    authorizationEndpoint: 'https://demo.identityserver.io/connect/authorize',
-    tokenEndpoint: 'https://demo.identityserver.io/connect/token'
-  }
+  scopes: ['openid', 'profile', 'email', 'offline_access']
+
+  // serviceConfiguration: {
+  //   authorizationEndpoint: 'https://demo.identityserver.io/connect/authorize',
+  //   tokenEndpoint: 'https://demo.identityserver.io/connect/token',
+  //   revocationEndpoint: 'https://demo.identityserver.io/connect/revoke'
+  // }
 };
 
 export default class App extends Component<{}, State> {

--- a/README.md
+++ b/README.md
@@ -72,14 +72,19 @@ const result = await authorize(config);
 This is your configuration object for the client. The config is passed into each of the methods
 with optional overrides.
 
-* **issuer** - (`string`) _REQUIRED_ the url of the auth server
+* **issuer** - (`string`) base URI of the authentication server. If no `serviceConfiguration` (below) is not provided, issuer is a mandatory field, so that the configuration can be fetched from the issuer's [OIDC discovery endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html).
+* **serviceConfiguration** - (`object`) you may manually configure token exchange endpoints in cases where the issuer does not support the OIDC discovery protocol, or simply to avoid an additional round trip to fetch the configuration. If no `issuer` (above) is provided, the service configuration is mandatory.
+  * **authorizationEndpoint** - (`string`) _REQUIRED_ fully formed url to the OAuth authorization endpoint
+  * **tokenEndpoint** - (`string`) _REQUIRED_ fully formed url to the OAuth token exchange endpoint
+  * **revocationEndpoint** - (`string`) fully formed url to the OAuth token revocation endpoint. If you want to be able to revoke a token and no `issuer` is specified, this field is mandatory.
 * **clientId** - (`string`) _REQUIRED_ your client id on the auth server
+* **clientSecret** - (`string`) client secret to pass to token exchange requests. :warning: Read more about [client secrets](#note-about-client-secrets)
 * **redirectUrl** - (`string`) _REQUIRED_ the url that links back to your app with the auth code
 * **scopes** - (`array<string>`) _REQUIRED_ the scopes for your token, e.g. `['email', 'offline_access']`
 * **additionalParameters** - (`object`) additional parameters that will be passed in the authorization request.
   Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
   `hello=world&foo=bar` to the authorization request.
-* :warning: **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. Can be useful for testing against local server, _should not be used in production._ This setting has no effect on iOS; to enable insecure HTTP requests, add a [NSExceptionAllowsInsecureHTTPLoads exception](https://cocoacasts.com/how-to-add-app-transport-security-exception-domains) to your App Transport Security settings.
+* **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. :warning: Can be useful for testing against local server, _should not be used in production._ This setting has no effect on iOS; to enable insecure HTTP requests, add a [NSExceptionAllowsInsecureHTTPLoads exception](https://cocoacasts.com/how-to-add-app-transport-security-exception-domains) to your App Transport Security settings.
 
 #### result
 
@@ -352,6 +357,14 @@ try {
 ```
 
 See example configurations for different providers below.
+
+### Note about client secrets
+
+Some authentication providers, including examples cited below, require you to provide a client secret. The authors of the AppAuth library
+
+> [strongly recommend](https://github.com/openid/AppAuth-Android#utilizing-client-secrets-dangerous) you avoid using static client secrets in your native applications whenever possible. Client secrets derived via a dynamic client registration are safe to use, but static client secrets can be easily extracted from your apps and allow others to impersonate your app and steal user data. If client secrets must be used by the OAuth2 provider you are integrating with, we strongly recommend performing the code exchange step on your backend, where the client secret can be kept hidden.
+
+Having said this, in some cases using client secrets is unavoidable. In these cases, a `clientSecret` parameter can be provided to `authorize`/`refresh` calls when performing a token request.
 
 ### Identity Server 4
 

--- a/README.md
+++ b/README.md
@@ -481,6 +481,42 @@ const refreshedState = await refresh(config, {
 });
 ```
 
+### Uber
+
+Uber provides an OAuth 2.0 endpoint for logging in with a Uber user's credentiala. You'll need to first [create an Uber OAuth application here](https://developer.uber.com/docs/riders/guides/authentication/introduction).
+
+Please note:
+
+* Uber does not provide a OIDC discovery endpoint, so `serviceConfiguration` is used instead.
+* Uber OAuth requires a [client secret](#note-about-client-secrets).
+
+```js
+const config = {
+  clientId: 'your-client-id-generated-by-uber',
+  clientSecret: 'your-client-id-generated-by-uber',
+  redirectUrl: 'com.whatever.url.you.configured.in.uber.oauth://redirect', //note: path is required
+  scopes: ['profile', 'delivery'], // whatever scopes you configured in Uber OAuth portal
+  serviceConfiguration: {
+    authorizationEndpoint: 'https://login.uber.com/oauth/v2/authorize',
+    tokenEndpoint: 'https://login.uber.com/oauth/v2/token',
+    revocationEndpoint: 'https://login.uber.com/oauth/v2/revoke'
+  }
+};
+
+// Log in to get an authentication token
+const authState = await authorize(config);
+
+// Refresh token
+const refreshedState = await refresh(config, {
+  refreshToken: authState.refreshToken,
+});
+
+// Revoke token
+await revoke(config, {
+  tokenToRevoke: refreshedState.refreshToken
+});
+```
+
 ## Contributors
 
 Thanks goes to these wonderful people

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ Please note:
 ```js
 const config = {
   clientId: 'your-client-id-generated-by-uber',
-  clientSecret: 'your-client-id-generated-by-uber',
+  clientSecret: 'your-client-secret-generated-by-uber',
   redirectUrl: 'com.whatever.url.you.configured.in.uber.oauth://redirect', //note: path is required
   scopes: ['profile', 'delivery'], // whatever scopes you configured in Uber OAuth portal
   serviceConfiguration: {

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ const result = await authorize(config);
 This is your configuration object for the client. The config is passed into each of the methods
 with optional overrides.
 
-* **issuer** - (`string`) base URI of the authentication server. If no `serviceConfiguration` (below) is not provided, issuer is a mandatory field, so that the configuration can be fetched from the issuer's [OIDC discovery endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html).
+* **issuer** - (`string`) base URI of the authentication server. If no `serviceConfiguration` (below) is provided, issuer is a mandatory field, so that the configuration can be fetched from the issuer's [OIDC discovery endpoint](https://openid.net/specs/openid-connect-discovery-1_0.html).
 * **serviceConfiguration** - (`object`) you may manually configure token exchange endpoints in cases where the issuer does not support the OIDC discovery protocol, or simply to avoid an additional round trip to fetch the configuration. If no `issuer` (above) is provided, the service configuration is mandatory.
   * **authorizationEndpoint** - (`string`) _REQUIRED_ fully formed url to the OAuth authorization endpoint
   * **tokenEndpoint** - (`string`) _REQUIRED_ fully formed url to the OAuth token exchange endpoint
@@ -483,7 +483,7 @@ const refreshedState = await refresh(config, {
 
 ### Uber
 
-Uber provides an OAuth 2.0 endpoint for logging in with a Uber user's credentiala. You'll need to first [create an Uber OAuth application here](https://developer.uber.com/docs/riders/guides/authentication/introduction).
+Uber provides an OAuth 2.0 endpoint for logging in with a Uber user's credentials. You'll need to first [create an Uber OAuth application here](https://developer.uber.com/docs/riders/guides/authentication/introduction).
 
 Please note:
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ with optional overrides.
   * **authorizationEndpoint** - (`string`) _REQUIRED_ fully formed url to the OAuth authorization endpoint
   * **tokenEndpoint** - (`string`) _REQUIRED_ fully formed url to the OAuth token exchange endpoint
   * **revocationEndpoint** - (`string`) fully formed url to the OAuth token revocation endpoint. If you want to be able to revoke a token and no `issuer` is specified, this field is mandatory.
+  * **registrationEndpoint** - (`string`) fully formed url to your OAuth/OpenID Connect registration endpoint. Only necessary for servers that require client registration.
 * **clientId** - (`string`) _REQUIRED_ your client id on the auth server
 * **clientSecret** - (`string`) client secret to pass to token exchange requests. :warning: Read more about [client secrets](#note-about-client-secrets)
 * **redirectUrl** - (`string`) _REQUIRED_ the url that links back to your app with the auth code

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -53,6 +53,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     private Promise promise;
     private Boolean dangerouslyAllowInsecureHttpRequests;
     private Map<String, String> additionalParametersMap;
+    private String clientSecret;
 
     public RNAppAuthModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -201,6 +202,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             String issuer,
             final String redirectUrl,
             final String clientId,
+            final String clientSecret,
             final ReadableArray scopes,
             final ReadableMap additionalParameters,
             final ReadableMap serviceConfiguration,
@@ -208,12 +210,14 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Promise promise
     ) {
 
-
-
         final String scopesString = this.arrayToString(scopes);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
         final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
         final HashMap<String, String> additionalParametersMap = MapUtils.readableMapToHashMap(additionalParameters);
+
+        if (clientSecret != null) {
+            additionalParametersMap.put("client_secret", clientSecret);
+        }
 
         // store args in private fields for later use in onActivityResult handler
         this.promise = promise;
@@ -294,6 +298,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             String issuer,
             final String redirectUrl,
             final String clientId,
+            final String clientSecret,
             final String refreshToken,
             final ReadableArray scopes,
             final ReadableMap additionalParameters,
@@ -307,6 +312,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
         final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder);
         final HashMap<String, String> additionalParametersMap = MapUtils.readableMapToHashMap(additionalParameters);
+
+        if (clientSecret != null) {
+            additionalParametersMap.put("client_secret", clientSecret);
+        }
 
         // store setting in private field for later use in onActivityResult handler
         this.dangerouslyAllowInsecureHttpRequests = dangerouslyAllowInsecureHttpRequests;

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.facebook.react.bridge.ActivityEventListener;
@@ -15,7 +14,6 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
-import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.WritableMap;
 import com.reactlibrary.utils.MapUtils;
 import com.reactlibrary.utils.UnsafeConnectionBuilder;
@@ -26,26 +24,17 @@ import net.openid.appauth.AuthorizationRequest;
 import net.openid.appauth.AuthorizationResponse;
 import net.openid.appauth.AuthorizationService;
 import net.openid.appauth.AuthorizationServiceConfiguration;
-import net.openid.appauth.Preconditions;
 import net.openid.appauth.ResponseTypeValues;
 import net.openid.appauth.TokenResponse;
 import net.openid.appauth.TokenRequest;
 import net.openid.appauth.connectivity.ConnectionBuilder;
 import net.openid.appauth.connectivity.DefaultConnectionBuilder;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.sql.Connection;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 public class RNAppAuthModule extends ReactContextBaseJavaModule implements ActivityEventListener {
 
@@ -53,148 +42,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     private Promise promise;
     private Boolean dangerouslyAllowInsecureHttpRequests;
     private Map<String, String> additionalParametersMap;
-    private String clientSecret;
 
     public RNAppAuthModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         reactContext.addActivityEventListener(this);
-    }
-
-
-    private String arrayToString(ReadableArray array) {
-        StringBuilder strBuilder = new StringBuilder();
-        for (int i = 0; i < array.size(); i++) {
-            if (i != 0) {
-                strBuilder.append(' ');
-            }
-            strBuilder.append(array.getString(i));
-        }
-        return strBuilder.toString();
-    }
-
-    private WritableMap tokenResponseToMap(TokenResponse response) {
-
-        Date expirationDate = new Date(response.accessTokenExpirationTime);
-        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
-        String expirationDateString = formatter.format(expirationDate);
-        WritableMap additionalParametersMap = Arguments.createMap();
-
-        if (!response.additionalParameters.isEmpty()) {
-
-            Iterator<String> iterator = response.additionalParameters.keySet().iterator();
-
-            while(iterator.hasNext()) {
-                String key = iterator.next();
-                additionalParametersMap.putString(key, response.additionalParameters.get(key));
-            }
-        }
-
-        WritableMap map = Arguments.createMap();
-        map.putString("accessToken", response.accessToken);
-        map.putString("accessTokenExpirationDate", expirationDateString);
-        map.putMap("additionalParameters", additionalParametersMap);
-        map.putString("idToken", response.idToken);
-        map.putString("refreshToken", response.refreshToken);
-        map.putString("tokenType", response.tokenType);
-
-        return map;
-    }
-
-
-    private AppAuthConfiguration createAppAuthConfiguration(ConnectionBuilder connectionBuilder) {
-        return new AppAuthConfiguration
-                .Builder()
-                .setConnectionBuilder(connectionBuilder)
-                .build();
-    }
-
-    private ConnectionBuilder createConnectionBuilder(Boolean allowInsecureConnections) {
-        if (allowInsecureConnections.equals(true)) {
-            return UnsafeConnectionBuilder.INSTANCE;
-        }
-
-        return DefaultConnectionBuilder.INSTANCE;
-    }
-
-    private Uri buildConfigurationUriFromIssuer(Uri openIdConnectIssuerUri) {
-        return openIdConnectIssuerUri.buildUpon()
-                .appendPath(AuthorizationServiceConfiguration.WELL_KNOWN_PATH)
-                .appendPath(AuthorizationServiceConfiguration.OPENID_CONFIGURATION_RESOURCE)
-                .build();
-    }
-
-    private void authorizeWithConfiguration(
-            final AuthorizationServiceConfiguration serviceConfiguration,
-            final AppAuthConfiguration appAuthConfiguration,
-            final String clientId,
-            final String scopesString,
-            final String redirectUrl,
-            final Map<String, String> additionalParametersMap
-    ) {
-
-        final Context context = this.reactContext;
-        final Activity currentActivity = getCurrentActivity();
-
-        AuthorizationRequest.Builder authRequestBuilder =
-                new AuthorizationRequest.Builder(
-                        serviceConfiguration,
-                        clientId,
-                        ResponseTypeValues.CODE,
-                        Uri.parse(redirectUrl)
-                )
-                        .setScope(scopesString);
-
-        if (additionalParametersMap != null) {
-            authRequestBuilder.setAdditionalParameters(additionalParametersMap);
-        }
-
-        AuthorizationRequest authRequest = authRequestBuilder.build();
-        AuthorizationService authService = new AuthorizationService(context, appAuthConfiguration);
-        Intent authIntent = authService.getAuthorizationRequestIntent(authRequest);
-        currentActivity.startActivityForResult(authIntent, 0);
-    }
-
-    private void refreshWithConfiguration(
-            final AuthorizationServiceConfiguration serviceConfiguration,
-            final AppAuthConfiguration appAuthConfiguration,
-            final String refreshToken,
-            final String clientId,
-            final String scopesString,
-            final String redirectUrl,
-            final Map<String, String> additionalParametersMap,
-            final Promise promise
-    ) {
-
-        final Context context = this.reactContext;
-
-        TokenRequest.Builder tokenRequestBuilder =
-                new TokenRequest.Builder(
-                        serviceConfiguration,
-                        clientId
-                )
-                        .setScope(scopesString)
-                        .setRefreshToken(refreshToken)
-                        .setRedirectUri(Uri.parse(redirectUrl));
-
-        if (!additionalParametersMap.isEmpty()) {
-            tokenRequestBuilder.setAdditionalParameters(additionalParametersMap);
-        }
-
-        TokenRequest tokenRequest = tokenRequestBuilder.build();
-
-        AuthorizationService authService = new AuthorizationService(context, appAuthConfiguration);
-        authService.performTokenRequest(tokenRequest, new AuthorizationService.TokenResponseCallback() {
-            @Override
-            public void onTokenRequestCompleted(@Nullable TokenResponse response, @Nullable AuthorizationException ex) {
-                if (response != null) {
-                    WritableMap map = tokenResponseToMap(response);
-                    promise.resolve(map);
-                } else {
-                    promise.reject("RNAppAuth Error", "Failed refresh token");
-                }
-            }
-        });
     }
 
     @ReactMethod
@@ -226,41 +78,18 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
         if (serviceConfiguration != null) {
-
-            // @TODO Refactor validation
-            if (!serviceConfiguration.hasKey("authorizationEndpoint")) {
-                promise.reject("RNAppAuth Error", "serviceConfiguration passed without an authorizationEndpoint");
-                return;
+            try {
+                authorizeWithConfiguration(
+                        createAuthorizationServiceConfiguration(serviceConfiguration),
+                        appAuthConfiguration,
+                        clientId,
+                        scopesString,
+                        redirectUrl,
+                        additionalParametersMap
+                );
+            } catch (Exception e) {
+                promise.reject(e);
             }
-
-            if (!serviceConfiguration.hasKey("tokenEndpoint")) {
-                promise.reject("RNAppAuth Error", "serviceConfiguration passed without a tokenEndpoint");
-                return;
-            }
-
-            Uri authorizationEndpoint = Uri.parse(serviceConfiguration.getString("authorizationEndpoint"));
-            Uri tokenEndpoint = Uri.parse(serviceConfiguration.getString("tokenEndpoint"));
-            Uri registrationEndpoint = null;
-
-            if (serviceConfiguration.hasKey("registrationEndpoint")) {
-                registrationEndpoint = Uri.parse(serviceConfiguration.getString("registrationEndPoint"));
-            }
-
-
-            AuthorizationServiceConfiguration authorizationServiceConfiguration = new AuthorizationServiceConfiguration(
-                    authorizationEndpoint,
-                    tokenEndpoint,
-                    registrationEndpoint
-            );
-
-            authorizeWithConfiguration(
-                    authorizationServiceConfiguration,
-                    appAuthConfiguration,
-                    clientId,
-                    scopesString,
-                    redirectUrl,
-                    additionalParametersMap
-            );
         } else {
             final Uri issuerUri = Uri.parse(issuer);
             AuthorizationServiceConfiguration.fetchFromUrl(
@@ -323,46 +152,22 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
         if (serviceConfiguration != null) {
-
-            // @TODO Refactor validation
-            if (!serviceConfiguration.hasKey("authorizationEndpoint")) {
-                promise.reject("RNAppAuth Error", "serviceConfiguration passed without an authorizationEndpoint");
-                return;
+            try {
+                refreshWithConfiguration(
+                        createAuthorizationServiceConfiguration(serviceConfiguration),
+                        appAuthConfiguration,
+                        refreshToken,
+                        clientId,
+                        scopesString,
+                        redirectUrl,
+                        additionalParametersMap,
+                        promise
+                );
+            } catch (Exception e) {
+                promise.reject(e);
             }
-
-            if (!serviceConfiguration.hasKey("tokenEndpoint")) {
-                promise.reject("RNAppAuth Error", "serviceConfiguration passed without a tokenEndpoint");
-                return;
-            }
-
-            Uri authorizationEndpoint = Uri.parse(serviceConfiguration.getString("authorizationEndpoint"));
-            Uri tokenEndpoint = Uri.parse(serviceConfiguration.getString("tokenEndpoint"));
-            Uri registrationEndpoint = null;
-
-            if (serviceConfiguration.hasKey("registrationEndpoint")) {
-                registrationEndpoint = Uri.parse(serviceConfiguration.getString("registrationEndPoint"));
-            }
-
-
-            AuthorizationServiceConfiguration authorizationServiceConfiguration = new AuthorizationServiceConfiguration(
-                    authorizationEndpoint,
-                    tokenEndpoint,
-                    registrationEndpoint
-            );
-
-            refreshWithConfiguration(
-                    authorizationServiceConfiguration,
-                    appAuthConfiguration,
-                    refreshToken,
-                    clientId,
-                    scopesString,
-                    redirectUrl,
-                    additionalParametersMap,
-                    promise
-            );
         } else {
-            // @TODO: Refactor to avoid hitting IDP endpoint on refresh, reuse fetchedConfiguration
-            // if possible.
+            // @TODO: Refactor to avoid hitting IDP endpoint on refresh, reuse fetchedConfiguration if possible.
             AuthorizationServiceConfiguration.fetchFromUrl(
                     buildConfigurationUriFromIssuer(issuerUri),
                     new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
@@ -391,6 +196,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
     }
 
+    /*
+     * Called when the OAuth browser activity completes
+     */
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         if (requestCode == 0) {
@@ -427,6 +235,185 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         }
     }
+
+    /*
+     * Authorize user with the provided configuration
+     */
+    private void authorizeWithConfiguration(
+            final AuthorizationServiceConfiguration serviceConfiguration,
+            final AppAuthConfiguration appAuthConfiguration,
+            final String clientId,
+            final String scopesString,
+            final String redirectUrl,
+            final Map<String, String> additionalParametersMap
+    ) {
+
+        final Context context = this.reactContext;
+        final Activity currentActivity = getCurrentActivity();
+
+        AuthorizationRequest.Builder authRequestBuilder =
+                new AuthorizationRequest.Builder(
+                        serviceConfiguration,
+                        clientId,
+                        ResponseTypeValues.CODE,
+                        Uri.parse(redirectUrl)
+                )
+                        .setScope(scopesString);
+
+        if (additionalParametersMap != null) {
+            authRequestBuilder.setAdditionalParameters(additionalParametersMap);
+        }
+
+        AuthorizationRequest authRequest = authRequestBuilder.build();
+        AuthorizationService authService = new AuthorizationService(context, appAuthConfiguration);
+        Intent authIntent = authService.getAuthorizationRequestIntent(authRequest);
+        currentActivity.startActivityForResult(authIntent, 0);
+    }
+
+    /*
+     * Refresh authentication token with the provided configuration
+     */
+    private void refreshWithConfiguration(
+            final AuthorizationServiceConfiguration serviceConfiguration,
+            final AppAuthConfiguration appAuthConfiguration,
+            final String refreshToken,
+            final String clientId,
+            final String scopesString,
+            final String redirectUrl,
+            final Map<String, String> additionalParametersMap,
+            final Promise promise
+    ) {
+
+        final Context context = this.reactContext;
+
+        TokenRequest.Builder tokenRequestBuilder =
+                new TokenRequest.Builder(
+                        serviceConfiguration,
+                        clientId
+                )
+                        .setScope(scopesString)
+                        .setRefreshToken(refreshToken)
+                        .setRedirectUri(Uri.parse(redirectUrl));
+
+        if (!additionalParametersMap.isEmpty()) {
+            tokenRequestBuilder.setAdditionalParameters(additionalParametersMap);
+        }
+
+        TokenRequest tokenRequest = tokenRequestBuilder.build();
+
+        AuthorizationService authService = new AuthorizationService(context, appAuthConfiguration);
+        authService.performTokenRequest(tokenRequest, new AuthorizationService.TokenResponseCallback() {
+            @Override
+            public void onTokenRequestCompleted(@Nullable TokenResponse response, @Nullable AuthorizationException ex) {
+                if (response != null) {
+                    WritableMap map = tokenResponseToMap(response);
+                    promise.resolve(map);
+                } else {
+                    promise.reject("RNAppAuth Error", "Failed refresh token");
+                }
+            }
+        });
+    }
+
+    /*
+     * Create a space-delimited string from an array
+     */
+    private String arrayToString(ReadableArray array) {
+        StringBuilder strBuilder = new StringBuilder();
+        for (int i = 0; i < array.size(); i++) {
+            if (i != 0) {
+                strBuilder.append(' ');
+            }
+            strBuilder.append(array.getString(i));
+        }
+        return strBuilder.toString();
+    }
+
+    /*
+     * Read raw token response into a React Native map to be passed down the bridge
+     */
+    private WritableMap tokenResponseToMap(TokenResponse response) {
+
+        Date expirationDate = new Date(response.accessTokenExpirationTime);
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        String expirationDateString = formatter.format(expirationDate);
+        WritableMap additionalParametersMap = Arguments.createMap();
+
+        if (!response.additionalParameters.isEmpty()) {
+
+            Iterator<String> iterator = response.additionalParameters.keySet().iterator();
+
+            while(iterator.hasNext()) {
+                String key = iterator.next();
+                additionalParametersMap.putString(key, response.additionalParameters.get(key));
+            }
+        }
+
+        WritableMap map = Arguments.createMap();
+        map.putString("accessToken", response.accessToken);
+        map.putString("accessTokenExpirationDate", expirationDateString);
+        map.putMap("additionalParameters", additionalParametersMap);
+        map.putString("idToken", response.idToken);
+        map.putString("refreshToken", response.refreshToken);
+        map.putString("tokenType", response.tokenType);
+
+        return map;
+    }
+
+    /*
+     * Create an App Auth configuration using the provided connection builder
+     */
+    private AppAuthConfiguration createAppAuthConfiguration(ConnectionBuilder connectionBuilder) {
+        return new AppAuthConfiguration
+                .Builder()
+                .setConnectionBuilder(connectionBuilder)
+                .build();
+    }
+
+    /*
+     *  Create appropriate connection builder based on provided settings
+     */
+    private ConnectionBuilder createConnectionBuilder(Boolean allowInsecureConnections) {
+        if (allowInsecureConnections.equals(true)) {
+            return UnsafeConnectionBuilder.INSTANCE;
+        }
+
+        return DefaultConnectionBuilder.INSTANCE;
+    }
+
+    /*
+     *  Replicated private method from AuthorizationServiceConfiguration
+     */
+    private Uri buildConfigurationUriFromIssuer(Uri openIdConnectIssuerUri) {
+        return openIdConnectIssuerUri.buildUpon()
+                .appendPath(AuthorizationServiceConfiguration.WELL_KNOWN_PATH)
+                .appendPath(AuthorizationServiceConfiguration.OPENID_CONFIGURATION_RESOURCE)
+                .build();
+    }
+
+    private AuthorizationServiceConfiguration createAuthorizationServiceConfiguration(ReadableMap serviceConfiguration) throws Exception {
+        if (!serviceConfiguration.hasKey("authorizationEndpoint")) {
+            throw new Exception("serviceConfiguration passed without an authorizationEndpoint");
+        }
+
+        if (!serviceConfiguration.hasKey("tokenEndpoint")) {
+            throw new Exception("serviceConfiguration passed without a tokenEndpoint");
+        }
+
+        Uri authorizationEndpoint = Uri.parse(serviceConfiguration.getString("authorizationEndpoint"));
+        Uri tokenEndpoint = Uri.parse(serviceConfiguration.getString("tokenEndpoint"));
+        Uri registrationEndpoint = null;
+        if (serviceConfiguration.hasKey("registrationEndpoint")) {
+            registrationEndpoint = Uri.parse(serviceConfiguration.getString("registrationEndPoint"));
+        }
+
+        return new AuthorizationServiceConfiguration(
+                authorizationEndpoint,
+                tokenEndpoint,
+                registrationEndpoint
+        );
+    }
+
 
     @Override
     public void onNewIntent(Intent intent) {

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -88,7 +88,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         additionalParametersMap
                 );
             } catch (Exception e) {
-                promise.reject(e);
+                promise.reject("RNAppAuth Error", "Failed to authenticate", e);
             }
         } else {
             final Uri issuerUri = Uri.parse(issuer);
@@ -135,9 +135,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Boolean dangerouslyAllowInsecureHttpRequests,
             final Promise promise
     ) {
-        final Context context = this.reactContext;
         final String scopesString = this.arrayToString(scopes);
-        final Uri issuerUri = Uri.parse(issuer);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
         final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder);
         final HashMap<String, String> additionalParametersMap = MapUtils.readableMapToHashMap(additionalParameters);
@@ -164,9 +162,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         promise
                 );
             } catch (Exception e) {
-                promise.reject(e);
+                promise.reject("RNAppAuth Error", "Failed to refresh token", e);
             }
         } else {
+            final Uri issuerUri = Uri.parse(issuer);
             // @TODO: Refactor to avoid hitting IDP endpoint on refresh, reuse fetchedConfiguration if possible.
             AuthorizationServiceConfiguration.fetchFromUrl(
                     buildConfigurationUriFromIssuer(issuerUri),

--- a/android/src/main/java/com/reactlibrary/utils/MapUtils.java
+++ b/android/src/main/java/com/reactlibrary/utils/MapUtils.java
@@ -7,10 +7,6 @@ import com.facebook.react.bridge.ReadableMapKeySetIterator;
 
 import java.util.HashMap;
 
-/**
- * Created by formidable on 21/02/2018.
- */
-
 public class MapUtils {
 
     public static HashMap<String, String> readableMapToHashMap(@Nullable ReadableMap readableMap) {

--- a/android/src/main/java/com/reactlibrary/utils/MapUtils.java
+++ b/android/src/main/java/com/reactlibrary/utils/MapUtils.java
@@ -1,0 +1,29 @@
+package com.reactlibrary.utils;
+
+import android.support.annotation.Nullable;
+
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.ReadableMapKeySetIterator;
+
+import java.util.HashMap;
+
+/**
+ * Created by formidable on 21/02/2018.
+ */
+
+public class MapUtils {
+
+    public static HashMap<String, String> readableMapToHashMap(@Nullable ReadableMap readableMap) {
+
+        HashMap<String, String> hashMap = new HashMap<>();
+        if (readableMap != null) {
+            ReadableMapKeySetIterator iterator = readableMap.keySetIterator();
+            while (iterator.hasNextKey()) {
+                String nextKey = iterator.nextKey();
+                hashMap.put(nextKey, readableMap.getString(nextKey));
+            }
+        }
+
+        return hashMap;
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,13 +2,20 @@ export interface ServiceConfiguration {
   authorizationEndpoint: string;
   tokenEndpoint: string;
   revocationEndpoint?: string;
+  registrationEndpoint?: string;
 }
 
-export interface BaseAuthConfiguration {
-  clientId: string;
-  issuer?: string;
-  serviceConfiguration?: ServiceConfiguration;
-}
+export type BaseAuthConfiguration =
+  | {
+      clientId: string;
+      issuer?: string;
+      serviceConfiguration: ServiceConfiguration;
+    }
+  | {
+      clientId: string;
+      issuer: string;
+      serviceConfiguration?: ServiceConfiguration;
+    };
 
 export interface AuthConfiguration extends BaseAuthConfiguration {
   clientSecret?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,17 @@
-export interface BaseAuthConfiguration {
-  issuer: string;
-  clientId: string;
+export interface ServiceConfiguration {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  revocationEndpoint?: string;
 }
+
+export interface BaseAuthConfiguration {
+  clientId: string;
+  issuer?: string;
+  serviceConfiguration?: ServiceConfiguration;
+}
+
 export interface AuthConfiguration extends BaseAuthConfiguration {
+  clientSecret?: string;
   scopes: string[];
   redirectUrl: string;
   additionalParameters?: { [name: string]: string };

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ export const authorize = ({
   clientId,
   scopes,
   additionalParameters,
+  serviceConfiguration,
   dangerouslyAllowInsecureHttpRequests = false,
 }) => {
   validateScopes(scopes);
@@ -26,7 +27,14 @@ export const authorize = ({
   validateRedirectUrl(redirectUrl);
   // TODO: validateAdditionalParameters
 
-  const nativeMethodArguments = [issuer, redirectUrl, clientId, scopes, additionalParameters];
+  const nativeMethodArguments = [
+    issuer,
+    redirectUrl,
+    clientId,
+    scopes,
+    additionalParameters,
+    serviceConfiguration,
+  ];
   if (Platform.OS === 'android') {
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
   }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceC
   invariant(
     typeof issuer === 'string' ||
       (serviceConfiguration && typeof serviceConfiguration.revocationEndPoint === 'string'),
-    'Config error: issuer must be a string'
+    'Config error: you must provide either an issue or a revocation endpoint'
   );
 const validateClientId = clientId =>
   invariant(typeof clientId === 'string', 'Config error: clientId must be a string');
@@ -108,7 +108,7 @@ export const revoke = async (
       'The openid config does not specify a revocation endpoint'
     );
 
-    revocationEndpoint = openidConfig.revocationEndpoint;
+    revocationEndpoint = openidConfig.revocation_endpoint;
   }
 
   /**

--- a/index.js
+++ b/index.js
@@ -5,12 +5,18 @@ const { RNAppAuth } = NativeModules;
 
 const validateScopes = scopes =>
   invariant(scopes && scopes.length, 'Scope error: please add at least one scope');
-const validateIssuer = issuer =>
-  invariant(typeof issuer === 'string', 'Config error: issuer must be a string');
+const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfiguration) =>
+  invariant(
+    typeof issuer === 'string' ||
+      (serviceConfiguration &&
+        typeof serviceConfiguration.authorizationEndpoint === 'string' &&
+        typeof serviceConfiguration.tokenEndpoint === 'string'),
+    'Config error: you must provide either an issue or a revocation endpoint'
+  );
 const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>
   invariant(
     typeof issuer === 'string' ||
-      (serviceConfiguration && typeof serviceConfiguration.revocationEndPoint === 'string'),
+      (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
     'Config error: you must provide either an issue or a revocation endpoint'
   );
 const validateClientId = clientId =>
@@ -29,7 +35,7 @@ export const authorize = ({
   dangerouslyAllowInsecureHttpRequests = false,
 }) => {
   validateScopes(scopes);
-  validateIssuer(issuer);
+  validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
   // TODO: validateAdditionalParameters
@@ -64,7 +70,7 @@ export const refresh = (
   { refreshToken }
 ) => {
   validateScopes(scopes);
-  validateIssuer(issuer);
+  validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
   invariant(refreshToken, 'Please pass in a refresh token');

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceC
   invariant(
     typeof issuer === 'string' ||
       (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
-    'Config error: you must provide either an issue or a revocation endpoint'
+    'Config error: you must provide either an issuer or a revocation endpoint'
   );
 const validateClientId = clientId =>
   invariant(typeof clientId === 'string', 'Config error: clientId must be a string');

--- a/index.js
+++ b/index.js
@@ -7,6 +7,12 @@ const validateScopes = scopes =>
   invariant(scopes && scopes.length, 'Scope error: please add at least one scope');
 const validateIssuer = issuer =>
   invariant(typeof issuer === 'string', 'Config error: issuer must be a string');
+const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>
+  invariant(
+    typeof issuer === 'string' ||
+      (serviceConfiguration && typeof serviceConfiguration.revocationEndPoint === 'string'),
+    'Config error: issuer must be a string'
+  );
 const validateClientId = clientId =>
   invariant(typeof clientId === 'string', 'Config error: clientId must be a string');
 const validateRedirectUrl = redirectUrl =>
@@ -88,18 +94,28 @@ export const refresh = (
   return RNAppAuth.refresh(...nativeMethodArguments);
 };
 
-export const revoke = async ({ clientId, issuer }, { tokenToRevoke, sendClientId = false }) => {
+export const revoke = async (
+  { clientId, issuer, serviceConfiguration },
+  { tokenToRevoke, sendClientId = false }
+) => {
   invariant(tokenToRevoke, 'Please include the token to revoke');
   validateClientId(clientId);
-  validateIssuer(issuer);
+  validateIssuerOrServiceConfigurationRevocationEndpoint(issuer, serviceConfiguration);
 
-  const response = await fetch(`${issuer}/.well-known/openid-configuration`);
-  const openidConfig = await response.json();
+  let revocationEndpoint;
+  if (serviceConfiguration && serviceConfiguration.revocationEndpoint) {
+    revocationEndpoint = serviceConfiguration.revocationEndpoint;
+  } else {
+    const response = await fetch(`${issuer}/.well-known/openid-configuration`);
+    const openidConfig = await response.json();
 
-  invariant(
-    openidConfig.revocation_endpoint,
-    'The openid config does not specify a revocation endpoint'
-  );
+    invariant(
+      openidConfig.revocation_endpoint,
+      'The openid config does not specify a revocation endpoint'
+    );
+
+    revocationEndpoint = openidConfig.revocationEndpoint;
+  }
 
   /**
     Identity Server insists on client_id being passed in the body,
@@ -107,8 +123,7 @@ export const revoke = async ({ clientId, issuer }, { tokenToRevoke, sendClientId
     so defaulting to no client_id
     https://tools.ietf.org/html/rfc7009#section-2.1
   **/
-
-  return await fetch(openidConfig.revocation_endpoint, {
+  return await fetch(revocationEndpoint, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfigurat
       (serviceConfiguration &&
         typeof serviceConfiguration.authorizationEndpoint === 'string' &&
         typeof serviceConfiguration.tokenEndpoint === 'string'),
-    'Config error: you must provide either an issue or a service endpoints'
+    'Config error: you must provide either an issuer or a service endpoints'
   );
 const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>
   invariant(

--- a/index.js
+++ b/index.js
@@ -34,16 +34,13 @@ export const authorize = ({
   validateRedirectUrl(redirectUrl);
   // TODO: validateAdditionalParameters
 
-  const nativeAdditionalParameters = clientSecret
-    ? { ...additionalParameters, client_secret: clientSecret } //eslint-disable-line camelcase
-    : additionalParameters;
-
   const nativeMethodArguments = [
     issuer,
     redirectUrl,
     clientId,
+    clientSecret,
     scopes,
-    nativeAdditionalParameters,
+    additionalParameters,
     serviceConfiguration,
   ];
   if (Platform.OS === 'android') {
@@ -73,17 +70,14 @@ export const refresh = (
   invariant(refreshToken, 'Please pass in a refresh token');
   // TODO: validateAdditionalParameters
 
-  const nativeAdditionalParameters = clientSecret
-    ? { ...additionalParameters, client_secret: clientSecret } //eslint-disable-line camelcase
-    : additionalParameters;
-
   const nativeMethodArguments = [
     issuer,
     redirectUrl,
     clientId,
+    clientSecret,
     refreshToken,
     scopes,
-    nativeAdditionalParameters,
+    additionalParameters,
     serviceConfiguration,
   ];
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ export const authorize = ({
   issuer,
   redirectUrl,
   clientId,
+  clientSecret,
   scopes,
   additionalParameters,
   serviceConfiguration,
@@ -27,12 +28,16 @@ export const authorize = ({
   validateRedirectUrl(redirectUrl);
   // TODO: validateAdditionalParameters
 
+  const nativeAdditionalParameters = clientSecret
+    ? { ...additionalParameters, client_secret: clientSecret } //eslint-disable-line camelcase
+    : additionalParameters;
+
   const nativeMethodArguments = [
     issuer,
     redirectUrl,
     clientId,
     scopes,
-    additionalParameters,
+    nativeAdditionalParameters,
     serviceConfiguration,
   ];
   if (Platform.OS === 'android') {
@@ -47,8 +52,10 @@ export const refresh = (
     issuer,
     redirectUrl,
     clientId,
+    clientSecret,
     scopes,
     additionalParameters,
+    serviceConfiguration,
     dangerouslyAllowInsecureHttpRequests = false,
   },
   { refreshToken }
@@ -60,13 +67,18 @@ export const refresh = (
   invariant(refreshToken, 'Please pass in a refresh token');
   // TODO: validateAdditionalParameters
 
+  const nativeAdditionalParameters = clientSecret
+    ? { ...additionalParameters, client_secret: clientSecret } //eslint-disable-line camelcase
+    : additionalParameters;
+
   const nativeMethodArguments = [
     issuer,
     redirectUrl,
     clientId,
     refreshToken,
     scopes,
-    additionalParameters,
+    nativeAdditionalParameters,
+    serviceConfiguration,
   ];
 
   if (Platform.OS === 'android') {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfigurat
       (serviceConfiguration &&
         typeof serviceConfiguration.authorizationEndpoint === 'string' &&
         typeof serviceConfiguration.tokenEndpoint === 'string'),
-    'Config error: you must provide either an issue or a revocation endpoint'
+    'Config error: you must provide either an issue or a service endpoints'
   );
 const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>
   invariant(

--- a/index.spec.js
+++ b/index.spec.js
@@ -40,10 +40,30 @@ describe('AppAuth', () => {
       mockRefresh.mockReset();
     });
 
-    it('throws an error when issuer is not a string', () => {
+    it('throws an error when issuer is not a string and serviceConfiguration is not passed', () => {
       expect(() => {
         authorize({ ...config, issuer: () => ({}) });
-      }).toThrow('Config error: issuer must be a string');
+      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+    });
+
+    it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
+      expect(() => {
+        authorize({
+          ...config,
+          issuer: undefined,
+          serviceConfiguration: { authorizationEndpoint: '' },
+        });
+      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+    });
+
+    it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
+      expect(() => {
+        authorize({
+          ...config,
+          issuer: undefined,
+          serviceConfiguration: { authorizationEndpoint: '' },
+        });
+      }).toThrow('Config error: you must provide either an issue or a service endpoints');
     });
 
     it('throws an error when redirectUrl is not a string', () => {
@@ -142,10 +162,30 @@ describe('AppAuth', () => {
       mockRefresh.mockReset();
     });
 
-    it('throws an error when issuer is not a string', () => {
+    it('throws an error when issuer is not a string and serviceConfiguration is not passed', () => {
       expect(() => {
         authorize({ ...config, issuer: () => ({}) });
-      }).toThrow('Config error: issuer must be a string');
+      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+    });
+
+    it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
+      expect(() => {
+        authorize({
+          ...config,
+          issuer: undefined,
+          serviceConfiguration: { authorizationEndpoint: '' },
+        });
+      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+    });
+
+    it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
+      expect(() => {
+        authorize({
+          ...config,
+          issuer: undefined,
+          serviceConfiguration: { authorizationEndpoint: '' },
+        });
+      }).toThrow('Config error: you must provide either an issue or a service endpoints');
     });
 
     it('throws an error when redirectUrl is not a string', () => {

--- a/index.spec.js
+++ b/index.spec.js
@@ -28,7 +28,9 @@ describe('AppAuth', () => {
     issuer: 'test-issuer',
     redirectUrl: 'test-redirectUrl',
     clientId: 'test-clientId',
+    clientSecret: 'test-clientSecret',
     additionalParameters: { hello: 'world' },
+    serviceConfiguration: null,
     scopes: ['my-scope'],
   };
 
@@ -74,8 +76,10 @@ describe('AppAuth', () => {
         config.issuer,
         config.redirectUrl,
         config.clientId,
+        config.clientSecret,
         config.scopes,
-        config.additionalParameters
+        config.additionalParameters,
+        config.serviceConfiguration
       );
     });
 
@@ -94,8 +98,10 @@ describe('AppAuth', () => {
           config.issuer,
           config.redirectUrl,
           config.clientId,
+          config.clientSecret,
           config.scopes,
           config.additionalParameters,
+          config.serviceConfiguration,
           false
         );
       });
@@ -106,8 +112,10 @@ describe('AppAuth', () => {
           config.issuer,
           config.redirectUrl,
           config.clientId,
+          config.clientSecret,
           config.scopes,
           config.additionalParameters,
+          config.serviceConfiguration,
           false
         );
       });
@@ -118,8 +126,10 @@ describe('AppAuth', () => {
           config.issuer,
           config.redirectUrl,
           config.clientId,
+          config.clientSecret,
           config.scopes,
           config.additionalParameters,
+          config.serviceConfiguration,
           true
         );
       });
@@ -174,9 +184,11 @@ describe('AppAuth', () => {
         config.issuer,
         config.redirectUrl,
         config.clientId,
+        config.clientSecret,
         'such-token',
         config.scopes,
-        config.additionalParameters
+        config.additionalParameters,
+        config.serviceConfiguration
       );
     });
 
@@ -195,9 +207,11 @@ describe('AppAuth', () => {
           config.issuer,
           config.redirectUrl,
           config.clientId,
+          config.clientSecret,
           'such-token',
           config.scopes,
           config.additionalParameters,
+          config.serviceConfiguration,
           false
         );
       });
@@ -211,9 +225,11 @@ describe('AppAuth', () => {
           config.issuer,
           config.redirectUrl,
           config.clientId,
+          config.clientSecret,
           'such-token',
           config.scopes,
           config.additionalParameters,
+          config.serviceConfiguration,
           false
         );
       });
@@ -227,9 +243,11 @@ describe('AppAuth', () => {
           config.issuer,
           config.redirectUrl,
           config.clientId,
+          config.clientSecret,
           'such-token',
           config.scopes,
           config.additionalParameters,
+          config.serviceConfiguration,
           true
         );
       });

--- a/index.spec.js
+++ b/index.spec.js
@@ -43,7 +43,7 @@ describe('AppAuth', () => {
     it('throws an error when issuer is not a string and serviceConfiguration is not passed', () => {
       expect(() => {
         authorize({ ...config, issuer: () => ({}) });
-      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+      }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
@@ -53,7 +53,7 @@ describe('AppAuth', () => {
           issuer: undefined,
           serviceConfiguration: { authorizationEndpoint: '' },
         });
-      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+      }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
@@ -63,7 +63,7 @@ describe('AppAuth', () => {
           issuer: undefined,
           serviceConfiguration: { authorizationEndpoint: '' },
         });
-      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+      }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when redirectUrl is not a string', () => {
@@ -165,7 +165,7 @@ describe('AppAuth', () => {
     it('throws an error when issuer is not a string and serviceConfiguration is not passed', () => {
       expect(() => {
         authorize({ ...config, issuer: () => ({}) });
-      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+      }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
@@ -175,7 +175,7 @@ describe('AppAuth', () => {
           issuer: undefined,
           serviceConfiguration: { authorizationEndpoint: '' },
         });
-      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+      }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
@@ -185,7 +185,7 @@ describe('AppAuth', () => {
           issuer: undefined,
           serviceConfiguration: { authorizationEndpoint: '' },
         });
-      }).toThrow('Config error: you must provide either an issue or a service endpoints');
+      }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when redirectUrl is not a string', () => {

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -27,14 +27,7 @@ RCT_REMAP_METHOD(authorize,
 {
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
-        NSURL *authorizationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"authorizationEndpoint"]];
-        NSURL *tokenEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"tokenEndpoint"]];
-        
-        OIDServiceConfiguration *configuration =
-        [[OIDServiceConfiguration alloc]
-         initWithAuthorizationEndpoint:authorizationEndpoint
-         tokenEndpoint:tokenEndpoint];
-        
+        OIDServiceConfiguration *configuration = [self createServiceConfiguration:serviceConfiguration];
         [self authorizeWithConfiguration: configuration
                              redirectUrl: redirectUrl
                                 clientId: clientId
@@ -51,7 +44,7 @@ RCT_REMAP_METHOD(authorize,
                                                                     reject(@"RNAppAuth Error", [error localizedDescription], error);
                                                                     return;
                                                                 }
-                                                                      
+                                                                
                                                                 [self authorizeWithConfiguration: configuration
                                                                                      redirectUrl: redirectUrl
                                                                                         clientId: clientId
@@ -78,14 +71,7 @@ RCT_REMAP_METHOD(refresh,
 {
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
-        NSURL *authorizationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"authorizationEndpoint"]];
-        NSURL *tokenEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"tokenEndpoint"]];
-        
-        OIDServiceConfiguration *configuration =
-        [[OIDServiceConfiguration alloc]
-         initWithAuthorizationEndpoint:authorizationEndpoint
-         tokenEndpoint:tokenEndpoint];
-        
+        OIDServiceConfiguration *configuration = [self createServiceConfiguration:serviceConfiguration];
         [self refreshWithConfiguration: configuration
                              redirectUrl: redirectUrl
                                 clientId: clientId
@@ -116,6 +102,24 @@ RCT_REMAP_METHOD(refresh,
                                                             }];
     }
 } // end RCT_REMAP_METHOD(refresh,
+
+
+/*
+ * Create a OIDServiceConfiguration from passed serviceConfiguration dictionary
+ */
+- (OIDServiceConfiguration *) createServiceConfiguration: (NSDictionary *) serviceConfiguration {
+    NSURL *authorizationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"authorizationEndpoint"]];
+    NSURL *tokenEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"tokenEndpoint"]];
+    NSURL *registrationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"registrationEndpoint"]];
+    
+    OIDServiceConfiguration *configuration =
+    [[OIDServiceConfiguration alloc]
+     initWithAuthorizationEndpoint:authorizationEndpoint
+     tokenEndpoint:tokenEndpoint
+     registrationEndpoint:registrationEndpoint];
+    
+    return configuration;
+}
 
 /*
  * Authorize a user in exchange for a token with provided OIDServiceConfiguration

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -11,125 +11,208 @@
 {
     return dispatch_get_main_queue();
 }
+
 RCT_EXPORT_MODULE()
 
 RCT_REMAP_METHOD(authorize,
                  issuer: (NSString *) issuer
                  redirectUrl: (NSString *) redirectUrl
                  clientId: (NSString *) clientId
+                 clientSecret: (NSString *) clientSecret
                  scopes: (NSArray *) scopes
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
-                 resolve:(RCTPromiseResolveBlock) resolve
+                 serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
+                 resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
-  [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
-                                                      completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
-                                                        if (!configuration) {
-                                                         reject(@"RNAppAuth Error", [error localizedDescription], error);
-                                                         return;
-                                                        }
-
-                                                        // builds authentication request
-                                                        OIDAuthorizationRequest *request =
-                                                        [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
-                                                                                                      clientId:clientId
-                                                                                                        scopes:scopes
-                                                                                                   redirectURL:[NSURL URLWithString:redirectUrl]
-                                                                                                  responseType:OIDResponseTypeCode
-                                                                                          additionalParameters:additionalParameters];
-
-
-                                                        // performs authentication request
-                                                        AppDelegate *appDelegate =
-                                                        (AppDelegate *)[UIApplication sharedApplication].delegate;
-
-                                                        appDelegate.currentAuthorizationFlow =
-                                                        [OIDAuthState authStateByPresentingAuthorizationRequest:request
-                                                                                       presentingViewController:appDelegate.window.rootViewController
-                                                                                                       callback:^(OIDAuthState *_Nullable authState,
-                                                                                                                  NSError *_Nullable error) {
-                                                                                                         if (authState) {
-                                                                                                           NSDate *expirationDate = authState.lastTokenResponse.accessTokenExpirationDate ? authState.lastTokenResponse.accessTokenExpirationDate : [NSDate alloc];
-
-                                                                                                           NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-                                                                                                           [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
-                                                                                                           NSString *exporationDateString = [dateFormat stringFromDate:expirationDate];
-
-                                                                                                           NSDictionary *authStateDict = @{
-                                                                                                                                           @"accessToken": authState.lastTokenResponse.accessToken,
-                                                                                                                                           @"accessTokenExpirationDate": exporationDateString,
-                                                                                                                                           @"additionalParameters": authState.lastTokenResponse.additionalParameters,
-                                                                                                                                           @"idToken": authState.lastTokenResponse.idToken,
-                                                                                                                                           @"refreshToken": authState.lastTokenResponse.refreshToken ? authState.lastTokenResponse.refreshToken : @"",
-                                                                                                                                           @"tokenType": authState.lastTokenResponse.tokenType,
-                                                                                                                                           };
-                                                                                                           resolve(authStateDict);
-                                                                                                         } else {
-                                                                                                           reject(@"RNAppAuth Error", [error localizedDescription], error);
-                                                                                                         }
-
-                                                                                                       }]; // end [OIDAuthState authStateByPresentingAuthorizationRequest:request
-
-                                                      }]; // end [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
-
+    // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
+    if (serviceConfiguration) {
+        NSURL *authorizationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"authorizationEndpoint"]];
+        NSURL *tokenEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"tokenEndpoint"]];
+        
+        OIDServiceConfiguration *configuration =
+        [[OIDServiceConfiguration alloc]
+         initWithAuthorizationEndpoint:authorizationEndpoint
+         tokenEndpoint:tokenEndpoint];
+        
+        [self authorizeWithConfiguration: configuration
+                             redirectUrl: redirectUrl
+                                clientId: clientId
+                            clientSecret: clientSecret
+                                  scopes: scopes
+                    additionalParameters: additionalParameters
+                                 resolve: resolve
+                                  reject: reject];
+        
+    } else {
+        [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
+                                                            completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
+                                                                if (!configuration) {
+                                                                    reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                                    return;
+                                                                }
+                                                                      
+                                                                [self authorizeWithConfiguration: configuration
+                                                                                     redirectUrl: redirectUrl
+                                                                                        clientId: clientId
+                                                                                    clientSecret: clientSecret
+                                                                                          scopes: scopes
+                                                                            additionalParameters: additionalParameters
+                                                                                         resolve: resolve
+                                                                                          reject: reject];
+                                                            }];
+    }
 } // end RCT_REMAP_METHOD(authorize,
 
 RCT_REMAP_METHOD(refresh,
                  issuer: (NSString *) issuer
                  redirectUrl: (NSString *) redirectUrl
                  clientId: (NSString *) clientId
+                 clientSecret: (NSString *) clientSecret
                  refreshToken: (NSString *) refreshToken
                  scopes: (NSArray *) scopes
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                 serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  resolve:(RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
-  [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
-                                                      completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
-                                                        if (!configuration) {
-                                                            reject(@"RNAppAuth Error", [error localizedDescription], error);
-                                                            return;
-                                                        }
-
-                                                        OIDTokenRequest *tokenRefreshRequest =
-                                                        [[OIDTokenRequest alloc] initWithConfiguration:configuration
-                                                                                             grantType:@"refresh_token"
-                                                                                     authorizationCode:nil
-                                                                                           redirectURL:[NSURL URLWithString:redirectUrl]
-                                                                                              clientID:clientId
-                                                                                          clientSecret:nil
-                                                                                                scopes:scopes
-                                                                                          refreshToken:refreshToken
-                                                                                          codeVerifier:nil
-                                                                                  additionalParameters:additionalParameters];
-
-                                                        [OIDAuthorizationService performTokenRequest:tokenRefreshRequest
-                                                                                            callback:^(OIDTokenResponse *_Nullable response,
-                                                                                                       NSError *_Nullable error) {
-
-                                                                                              if (response) {
-
-                                                                                                NSDate *expirationDate = response.accessTokenExpirationDate ?
-                                                                                                response.accessTokenExpirationDate : [NSDate alloc];
-
-                                                                                                NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-                                                                                                [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
-                                                                                                NSString *exporationDateString = [dateFormat stringFromDate:expirationDate];
-
-                                                                                                resolve(@{
-                                                                                                          @"accessToken": response.accessToken ? response.accessToken : @"",
-                                                                                                          @"accessTokenExpirationDate": exporationDateString,
-                                                                                                          @"additionalParameters": response.additionalParameters,
-                                                                                                          @"idToken": response.idToken ? response.idToken : @"",
-                                                                                                          @"refreshToken": response.refreshToken ? response.refreshToken : @"",
-                                                                                                          @"tokenType": response.tokenType ? response.tokenType : @"",
-                                                                                                          });
-                                                                                              } else {
-                                                                                                reject(@"RNAppAuth Error", [error localizedDescription], error);
-                                                                                              }
-                                                                                            }];
-
-                                                        }]; // end [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
+    // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
+    if (serviceConfiguration) {
+        NSURL *authorizationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"authorizationEndpoint"]];
+        NSURL *tokenEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"tokenEndpoint"]];
+        
+        OIDServiceConfiguration *configuration =
+        [[OIDServiceConfiguration alloc]
+         initWithAuthorizationEndpoint:authorizationEndpoint
+         tokenEndpoint:tokenEndpoint];
+        
+        [self refreshWithConfiguration: configuration
+                             redirectUrl: redirectUrl
+                                clientId: clientId
+                            clientSecret: clientSecret
+                            refreshToken: refreshToken
+                                  scopes: scopes
+                    additionalParameters: additionalParameters
+                                 resolve: resolve
+                                  reject: reject];
+        
+    } else {
+        // otherwise hit up the discovery endpoint
+        [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
+                                                            completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
+                                                                if (!configuration) {
+                                                                    reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                                    return;
+                                                                }
+                                                                [self refreshWithConfiguration: configuration
+                                                                                   redirectUrl: redirectUrl
+                                                                                      clientId: clientId
+                                                                                  clientSecret: clientSecret
+                                                                                  refreshToken: refreshToken
+                                                                                        scopes: scopes
+                                                                          additionalParameters: additionalParameters
+                                                                                       resolve: resolve
+                                                                                        reject: reject];
+                                                            }];
+    }
 } // end RCT_REMAP_METHOD(refresh,
+
+/*
+ * Authorize a user in exchange for a token with provided OIDServiceConfiguration
+ */
+- (void)authorizeWithConfiguration: (OIDServiceConfiguration *) configuration
+                       redirectUrl: (NSString *) redirectUrl
+                          clientId: (NSString *) clientId
+                      clientSecret: (NSString *) clientSecret
+                            scopes: (NSArray *) scopes
+              additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                           resolve: (RCTPromiseResolveBlock) resolve
+                            reject: (RCTPromiseRejectBlock)  reject
+{
+    // builds authentication request
+    OIDAuthorizationRequest *request =
+    [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
+                                                  clientId:clientId
+                                              clientSecret:clientSecret
+                                                    scopes:scopes
+                                               redirectURL:[NSURL URLWithString:redirectUrl]
+                                              responseType:OIDResponseTypeCode
+                                      additionalParameters:additionalParameters];
+    
+    
+    // performs authentication request
+    AppDelegate *appDelegate = (AppDelegate *)[UIApplication sharedApplication].delegate;
+    
+    appDelegate.currentAuthorizationFlow =
+    [OIDAuthState authStateByPresentingAuthorizationRequest:request
+                                   presentingViewController:appDelegate.window.rootViewController
+                                                   callback:^(OIDAuthState *_Nullable authState,
+                                                              NSError *_Nullable error) {
+                                                       if (authState) {
+                                                           resolve([self formatResponse:authState.lastTokenResponse]);
+                                                       } else {
+                                                           reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                       }
+                                                       
+                                                   }]; // end [OIDAuthState authStateByPresentingAuthorizationRequest:request
+}
+
+
+/*
+ * Refresh a token with provided OIDServiceConfiguration
+ */
+- (void)refreshWithConfiguration: (OIDServiceConfiguration *)configuration
+                     redirectUrl: (NSString *) redirectUrl
+                        clientId: (NSString *) clientId
+                    clientSecret: (NSString *) clientSecret
+                    refreshToken: (NSString *) refreshToken
+                          scopes: (NSArray *) scopes
+            additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                         resolve:(RCTPromiseResolveBlock) resolve
+                          reject: (RCTPromiseRejectBlock)  reject {
+    
+    OIDTokenRequest *tokenRefreshRequest =
+    [[OIDTokenRequest alloc] initWithConfiguration:configuration
+                                         grantType:@"refresh_token"
+                                 authorizationCode:nil
+                                       redirectURL:[NSURL URLWithString:redirectUrl]
+                                          clientID:clientId
+                                      clientSecret:clientSecret
+                                            scopes:scopes
+                                      refreshToken:refreshToken
+                                      codeVerifier:nil
+                              additionalParameters:additionalParameters];
+    
+    [OIDAuthorizationService performTokenRequest:tokenRefreshRequest
+                                        callback:^(OIDTokenResponse *_Nullable response,
+                                                   NSError *_Nullable error) {
+                                            if (response) {
+                                                resolve([self formatResponse:response]);
+                                            } else {
+                                                reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                            }
+                                        }];
+    
+}
+
+/*
+ * Take raw OIDTokenResponse and turn it to a token response format to pass to JavaScript caller
+ */
+- (NSDictionary*)formatResponse: (OIDTokenResponse*) response {
+    NSDate *expirationDate = response.accessTokenExpirationDate ?
+    response.accessTokenExpirationDate : [NSDate alloc];
+    
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
+    NSString *expirationDateString = [dateFormat stringFromDate:expirationDate];
+    
+    return @{@"accessToken": response.accessToken ? response.accessToken : @"",
+             @"accessTokenExpirationDate": expirationDateString,
+             @"additionalParameters": response.additionalParameters,
+             @"idToken": response.idToken ? response.idToken : @"",
+             @"refreshToken": response.refreshToken ? response.refreshToken : @"",
+             @"tokenType": response.tokenType ? response.tokenType : @"",
+             };
+}
 
 @end


### PR DESCRIPTION
Fixes #23.

Adds support for manually configuring service endpoints and supporting client secrets for non-OIDC-compliant OAuth services. 

## JavaScript
- [x] Add serviceConfiguration to API
- [x] Add clientSecret to API
- [x] Support `authorize`
- [x] Support `refresh`
- [x] Support `revoke`
- [x] Refactor
- [x] Update and add tests

## Android
- [x] Allow authorization with manual service configuration
- [x] Allow refresh with manual service configuration
- [x] Pass additionalProperties to token request to support client_secret
- [x] Refactor

## iOS
- [x] Allow authorization with manual service configuration
- [x] Allow refresh with manual service configuration
- [x] Pass client_secret

## Other
- [x] Update API documentation
- [x] Update TypeScript definitions
- [x] Add note/warning about using client secrets
- [x] Add example configuration for a manually configured service

With this, we should next be able to implement: 
- #28 Identity Server 3 compatibility
- #42 More presets/examples

