### PR TITLE
Remove double RevokeConfiguration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,11 +25,6 @@ export interface AuthConfiguration extends BaseAuthConfiguration {
   dangerouslyAllowInsecureHttpRequests?: boolean;
 }
 
-export interface RevokeConfiguration {
-  clientId: string;
-  issuer: string;
-}
-
 export interface AuthorizeResult {
   accessToken: string;
   accessTokenExpirationDate: string;


### PR DESCRIPTION
RevokeConfiguration was leftover from a previous edit, causes compiler to error.