### PR TITLE
Prevent exception in Android when using built-in parameters

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -273,6 +273,20 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         .setScope(scopesString);
 
         if (additionalParametersMap != null) {
+            // handle additional parameters separately to avoid exceptions from AppAuth
+            if (additionalParametersMap.containsKey("display")) {
+                authRequestBuilder.setDisplay(additionalParametersMap.get("display"));
+                additionalParametersMap.remove("display");
+            }
+            if (additionalParametersMap.containsKey("login_hint")) {
+                authRequestBuilder.setLoginHint(additionalParametersMap.get("login_hint"));
+                additionalParametersMap.remove("login_hint");
+            }
+            if (additionalParametersMap.containsKey("prompt")) {
+                authRequestBuilder.setPrompt(additionalParametersMap.get("prompt"));
+                additionalParametersMap.remove("prompt");
+            }
+
             authRequestBuilder.setAdditionalParameters(additionalParametersMap);
         }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,11 +17,17 @@ export type BaseAuthConfiguration =
       serviceConfiguration?: ServiceConfiguration;
     };
 
+interface BuiltInParameters {
+  display?: "page" | "popup" | "touch" | "wap";
+  login_prompt?: string;
+  prompt?: "consent" |"login" | "none" | "select_account";
+}
+
 export type AuthConfiguration = BaseAuthConfiguration & {
   clientSecret?: string;
   scopes: string[];
   redirectUrl: string;
-  additionalParameters?: { [name: string]: string };
+  additionalParameters?: BuiltInParameters & { [name: string]: string };
   dangerouslyAllowInsecureHttpRequests?: boolean;
 };
 


### PR DESCRIPTION
As described in #73, AppAuth in Android throws when some of the built-in parameters are used in the `additionalParameters` field.

As iOS version of AppAuth [does not handle those differently](https://github.com/openid/AppAuth-iOS/blob/f7b6bafd7593950e16819806f5d060a131a17228/Source/OIDTokenRequest.m#L26-L66) (and works as is), only the Android version is fixed to prevent the exceptions.

Additionally, the TypeScript declarations were updated to help users prevent typos in the enum-valued built-in parameters.