### PR TITLE
Make scopes an Array in the docs to avoid React Native crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ const config = {
   issuer: '<YOUR_ISSUER_URL>',
   clientId: '<YOUR_CLIENT_ID>',
   redirectUrl: '<YOUR_REDIRECT_URL>',
- scopes: ['<YOUR_SCOPES_ARRAY>'],
+  scopes: ['<YOUR_SCOPES_ARRAY>'],
 };
 
 // use the client to make the auth request and receive the authState

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ const config = {
   issuer: '<YOUR_ISSUER_URL>',
   clientId: '<YOUR_CLIENT_ID>',
   redirectUrl: '<YOUR_REDIRECT_URL>',
-  scopes: '<YOUR_SCOPES_ARRAY>'
+  scopes: ['<YOUR_SCOPES_ARRAY>'],
 };
 
 const result = await authorize(config);
@@ -113,7 +113,7 @@ const config = {
   issuer: '<YOUR_ISSUER_URL>',
   clientId: '<YOUR_CLIENT_ID>',
   redirectUrl: '<YOUR_REDIRECT_URL>',
-  scopes: '<YOUR_SCOPES_ARRAY>',
+  scopes: ['<YOUR_SCOPES_ARRAY>'],
 };
 
 const result = await refresh(config, {
@@ -132,7 +132,7 @@ const config = {
   issuer: '<YOUR_ISSUER_URL>',
   clientId: '<YOUR_CLIENT_ID>',
   redirectUrl: '<YOUR_REDIRECT_URL>',
-  scopes: '<YOUR_SCOPES_ARRAY>',
+  scopes: ['<YOUR_SCOPES_ARRAY>'],
 };
 
 const result = await revoke(config, {
@@ -348,7 +348,7 @@ const config = {
   issuer: '<YOUR_ISSUER_URL>',
   clientId: '<YOUR_CLIENT_ID>',
   redirectUrl: '<YOUR_REDIRECT_URL>',
-  scopes: '<YOUR_SCOPES_ARRAY>'
+ scopes: ['<YOUR_SCOPES_ARRAY>'],
 };
 
 // use the client to make the auth request and receive the authState


### PR DESCRIPTION
Otherwise it will be a hard and confusing crash for beginners if they keep scopes as a string.