### PR TITLE
Use correct clientSecret param in android native refresh implementation

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -354,7 +354,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
 
         if (clientSecret != null) {
-            ClientAuthentication clientAuth = new ClientSecretBasic(this.clientSecret);
+            ClientAuthentication clientAuth = new ClientSecretBasic(clientSecret);
             authService.performTokenRequest(tokenRequest, clientAuth, tokenResponseCallback);
 
         } else {


### PR DESCRIPTION
Before my change, the client secret used in `refresh` was taken from `this.clientSecret`.
`this.clientSecret` was only initialized in the `authorize` method,  so unless you called `authorize` before calling `refresh`,  the refresh operation would fail.  
This PR makes the `refresh` method use the clientSecret received as an argument, instead of `this.clientSecret`