### PR TITLE
Fix ClientSecret creation

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -26,7 +26,7 @@ import net.openid.appauth.AuthorizationResponse;
 import net.openid.appauth.AuthorizationService;
 import net.openid.appauth.AuthorizationServiceConfiguration;
 import net.openid.appauth.ClientAuthentication;
-import net.openid.appauth.ClientSecretBasic;
+import net.openid.appauth.ClientSecretPost;
 import net.openid.appauth.ResponseTypeValues;
 import net.openid.appauth.TokenResponse;
 import net.openid.appauth.TokenRequest;
@@ -239,7 +239,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             };
 
             if (this.clientSecret != null) {
-                ClientAuthentication clientAuth = new ClientSecretBasic(this.clientSecret);
+                ClientAuthentication clientAuth = new ClientSecretPost(this.clientSecret);
                 authService.performTokenRequest(tokenRequest, clientAuth, tokenResponseCallback);
 
             } else {
@@ -354,7 +354,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
 
         if (clientSecret != null) {
-            ClientAuthentication clientAuth = new ClientSecretBasic(clientSecret);
+            ClientAuthentication clientAuth = new ClientSecretPost(clientSecret);
             authService.performTokenRequest(tokenRequest, clientAuth, tokenResponseCallback);
 
         } else {


### PR DESCRIPTION
Please feel free to close this one if this this issue was happening because of the server configuration, but I would really appreciate some insight.

So the problem was:

In order to make oauth - I need to pass client secret, but with `ClientSecretBasic` it was failing with error like `Each request needs to have only one auth method` or something. Without secret - I couldn't  log in.

Is this not even an issue?

Many thanks in advance!