### PR TITLE
Hacky mechanism for preventing token exchange step 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:2.3.2'
     }
 }
 
@@ -13,7 +13,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion '25.0.0'
     
     defaultConfig {
         minSdkVersion 16

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -52,6 +52,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         this.reactContext = reactContext;
         reactContext.addActivityEventListener(this);
     }
+    @Override
+    public void onNewIntent(Intent intent) {
+
+    }
 
     @ReactMethod
     public void authorize(
@@ -211,7 +215,17 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             AuthorizationResponse response = AuthorizationResponse.fromIntent(data);
             AuthorizationException exception = AuthorizationException.fromIntent(data);
             if (exception != null) {
-                promise.reject("RNAppAuth Error", "Failed to authenticate", exception);
+                this.promise.reject("RNAppAuth Error", "Failed to authenticate", exception);
+                return;
+            }
+
+            if (this.additionalParametersMap.containsKey("skipTokenExchange")
+                    && this.additionalParametersMap.get("skipTokenExchange").equals("true")) {
+                WritableMap map = Arguments.createMap();
+                map.putString("code", response.authorizationCode);
+                map.putString("state", response.state);
+                map.putString("redirectUri", response.request.redirectUri.toString());
+                this.promise.resolve(map);
                 return;
             }
 
@@ -224,8 +238,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
             TokenRequest tokenRequest = response.createTokenExchangeRequest(this.additionalParametersMap);
 
-            AuthorizationService.TokenResponseCallback tokenResponseCallback = new AuthorizationService.TokenResponseCallback() {
-
+            AuthorizationService.TokenResponseCallback tokenResponseCallback
+                    = new AuthorizationService.TokenResponseCallback() {
                 @Override
                 public void onTokenRequestCompleted(
                         TokenResponse resp, AuthorizationException ex) {
@@ -447,12 +461,17 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             throw new Exception("serviceConfiguration passed without an authorizationEndpoint");
         }
 
-        if (!serviceConfiguration.hasKey("tokenEndpoint")) {
+        Uri tokenEndpoint = Uri.EMPTY;
+        if (serviceConfiguration.hasKey("tokenEndpoint")) {
+            tokenEndpoint = Uri.parse(serviceConfiguration.getString("tokenEndpoint"));
+        } else if (!this.additionalParametersMap.containsKey("skipTokenExchange")
+                || !this.additionalParametersMap.get("skipTokenExchange").equals("true")) {
+            // tokenEndpoint is required unless `skipTokenExchange` is set to true
             throw new Exception("serviceConfiguration passed without a tokenEndpoint");
         }
 
         Uri authorizationEndpoint = Uri.parse(serviceConfiguration.getString("authorizationEndpoint"));
-        Uri tokenEndpoint = Uri.parse(serviceConfiguration.getString("tokenEndpoint"));
+
         Uri registrationEndpoint = null;
         if (serviceConfiguration.hasKey("registrationEndpoint")) {
             registrationEndpoint = Uri.parse(serviceConfiguration.getString("registrationEndPoint"));
@@ -465,14 +484,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         );
     }
 
-
-    @Override
-    public void onNewIntent(Intent intent) {
-
-    }
-
     @Override
     public String getName() {
         return "RNAppAuth";
     }
+
 }

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -220,6 +220,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             }
 
             if (this.additionalParametersMap.containsKey("skipTokenExchange")
+                    && this.additionalParametersMap.get("skipTokenExchange") != null
                     && this.additionalParametersMap.get("skipTokenExchange").equals("true")) {
                 WritableMap map = Arguments.createMap();
                 map.putString("code", response.authorizationCode);

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ interface BuiltInParameters {
   display?: "page" | "popup" | "touch" | "wap";
   login_prompt?: string;
   prompt?: "consent" |"login" | "none" | "select_account";
+  skipTokenExchange: boolean;
 }
 
 export type AuthConfiguration = BaseAuthConfiguration & {
@@ -40,6 +41,12 @@ export interface AuthorizeResult {
   tokenType: string;
 }
 
+export interface AuthorizeWithoutTokenExchangeResult {
+  code: string; // i.e. authorizationCode
+  state: string;
+  redirectUri: string;
+}
+
 export interface RevokeConfiguration {
   tokenToRevoke: string;
   sendClientId?: boolean;
@@ -49,7 +56,7 @@ export interface RefreshConfiguration {
   refreshToken: string;
 }
 
-export function authorize(config: AuthConfiguration): Promise<AuthorizeResult>;
+export function authorize(config: AuthConfiguration): Promise<AuthorizeResult|AuthorizeWithoutTokenExchangeResult>;
 
 export function refresh(
   config: AuthConfiguration,

--- a/index.js
+++ b/index.js
@@ -9,8 +9,7 @@ const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfigurat
   invariant(
     typeof issuer === 'string' ||
       (serviceConfiguration &&
-        typeof serviceConfiguration.authorizationEndpoint === 'string' &&
-        typeof serviceConfiguration.tokenEndpoint === 'string'),
+        typeof serviceConfiguration.authorizationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a service endpoints'
   );
 const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>


### PR DESCRIPTION
This PR (discussed in https://github.com/FormidableLabs/react-native-app-auth/issues/96) adds support for a boolean `additionalParameter` called `skipTokenExchange` which will allow users to retrieve the OAuth authorization_code before it's exchanged for an access_token and id_token.

This is necessary for e.g. using this library in an application with a backend server that needs to access a user resource via client_secret (as opposed to the serverless OIDC flow).

