### PR TITLE
Set the locale and lock the time zone to UTC while formatting times

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -37,6 +37,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 
 public class RNAppAuthModule extends ReactContextBaseJavaModule implements ActivityEventListener {
@@ -386,7 +387,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         if (response.accessTokenExpirationTime != null) {
             Date expirationDate = new Date(response.accessTokenExpirationTime);
-            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+            formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
             String expirationDateString = formatter.format(expirationDate);
             map.putString("accessTokenExpirationDate", expirationDateString);
         }

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -36,7 +36,7 @@ RCT_REMAP_METHOD(authorize,
                     additionalParameters: additionalParameters
                                  resolve: resolve
                                   reject: reject];
-        
+
     } else {
         [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
                                                             completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
@@ -44,7 +44,7 @@ RCT_REMAP_METHOD(authorize,
                                                                     reject(@"RNAppAuth Error", [error localizedDescription], error);
                                                                     return;
                                                                 }
-                                                                
+
                                                                 [self authorizeWithConfiguration: configuration
                                                                                      redirectUrl: redirectUrl
                                                                                         clientId: clientId
@@ -81,7 +81,7 @@ RCT_REMAP_METHOD(refresh,
                     additionalParameters: additionalParameters
                                  resolve: resolve
                                   reject: reject];
-        
+
     } else {
         // otherwise hit up the discovery endpoint
         [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
@@ -111,13 +111,13 @@ RCT_REMAP_METHOD(refresh,
     NSURL *authorizationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"authorizationEndpoint"]];
     NSURL *tokenEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"tokenEndpoint"]];
     NSURL *registrationEndpoint = [NSURL URLWithString: [serviceConfiguration objectForKey:@"registrationEndpoint"]];
-    
+
     OIDServiceConfiguration *configuration =
     [[OIDServiceConfiguration alloc]
      initWithAuthorizationEndpoint:authorizationEndpoint
      tokenEndpoint:tokenEndpoint
      registrationEndpoint:registrationEndpoint];
-    
+
     return configuration;
 }
 
@@ -142,11 +142,11 @@ RCT_REMAP_METHOD(refresh,
                                                redirectURL:[NSURL URLWithString:redirectUrl]
                                               responseType:OIDResponseTypeCode
                                       additionalParameters:additionalParameters];
-    
-    
+
+
     // performs authentication request
     AppDelegate *appDelegate = (AppDelegate *)[UIApplication sharedApplication].delegate;
-    
+
     appDelegate.currentAuthorizationFlow =
     [OIDAuthState authStateByPresentingAuthorizationRequest:request
                                    presentingViewController:appDelegate.window.rootViewController
@@ -157,7 +157,7 @@ RCT_REMAP_METHOD(refresh,
                                                        } else {
                                                            reject(@"RNAppAuth Error", [error localizedDescription], error);
                                                        }
-                                                       
+
                                                    }]; // end [OIDAuthState authStateByPresentingAuthorizationRequest:request
 }
 
@@ -174,7 +174,7 @@ RCT_REMAP_METHOD(refresh,
             additionalParameters: (NSDictionary *_Nullable) additionalParameters
                          resolve:(RCTPromiseResolveBlock) resolve
                           reject: (RCTPromiseRejectBlock)  reject {
-    
+
     OIDTokenRequest *tokenRefreshRequest =
     [[OIDTokenRequest alloc] initWithConfiguration:configuration
                                          grantType:@"refresh_token"
@@ -186,7 +186,7 @@ RCT_REMAP_METHOD(refresh,
                                       refreshToken:refreshToken
                                       codeVerifier:nil
                               additionalParameters:additionalParameters];
-    
+
     [OIDAuthorizationService performTokenRequest:tokenRefreshRequest
                                         callback:^(OIDTokenResponse *_Nullable response,
                                                    NSError *_Nullable error) {
@@ -196,7 +196,7 @@ RCT_REMAP_METHOD(refresh,
                                                 reject(@"RNAppAuth Error", [error localizedDescription], error);
                                             }
                                         }];
-    
+
 }
 
 /*
@@ -204,7 +204,9 @@ RCT_REMAP_METHOD(refresh,
  */
 - (NSDictionary*)formatResponse: (OIDTokenResponse*) response {
     NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
-    [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ssZ"];
+    dateFormat.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
+    [dateFormat setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+    [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
 
     return @{@"accessToken": response.accessToken ? response.accessToken : @"",
              @"accessTokenExpirationDate": response.accessTokenExpirationDate ? [dateFormat stringFromDate:response.accessTokenExpirationDate] : @"",


### PR DESCRIPTION
Hi there!

We really love react-native-app-auth, and we came across a problem parsing timestamps in our application.

ISO8601 has a few different formats, but we found that the UTC-zoned format "yyyy-mm-ddThh:mm:ssZ" is parseable by the Javascript side of our app. Specifically, `Date.parse()` in JSCore seems to be unhappy with the non-Z style.

This PR switches to UTC as the timezone, and explicitly sets the zone to Z. We would love any feedback you've got to offer!

Thank you.