### PR TITLE
Fix registration endpoint key in Android

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -474,7 +474,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         Uri tokenEndpoint = Uri.parse(serviceConfiguration.getString("tokenEndpoint"));
         Uri registrationEndpoint = null;
         if (serviceConfiguration.hasKey("registrationEndpoint")) {
-            registrationEndpoint = Uri.parse(serviceConfiguration.getString("registrationEndPoint"));
+            registrationEndpoint = Uri.parse(serviceConfiguration.getString("registrationEndpoint"));
         }
 
         return new AuthorizationServiceConfiguration(


### PR DESCRIPTION
There is a mis-match of the key string in Android when you override the default configuration using serviceConfiguration key. If you set the registrationEndpoint it throws an exception.
