### PR TITLE
Android/Feature: Add method to prefetch once, reuse AutherizationServiceConfig

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,6 +27,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,10 +27,6 @@ android {
     lintOptions {
         abortOnError false
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 repositories {

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -70,7 +70,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Promise promise
     ) {
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
-        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
+        final CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
 
         if(!isPrefetched) {
             if (serviceConfiguration != null && mServiceConfiguration.get() == null) {

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -70,7 +70,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Promise promise
     ) {
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
-        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);¨
+        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
 
         if(!isPrefetched) {
             if (serviceConfiguration != null && mServiceConfiguration.get() == null) {

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -101,6 +101,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         builder
                 );
             }
+        } else {
+            fetchConfigurationLatch.countDown();
         }
         
         try {

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -7,7 +7,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.support.customtabs.CustomTabsIntent;
-import android.os.Build;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -54,9 +53,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     private Boolean dangerouslyAllowInsecureHttpRequests;
     private Map<String, String> additionalParametersMap;
     private String clientSecret;
-    private final AtomicReference<CustomTabsIntent> warmUpIntent = new AtomicReference<>();
-    private ExecutorService warmUpExecutor;
-    private CountDownLatch warmUpIntentLatch = new CountDownLatch(1);
+    private final AtomicReference<AuthorizationServiceConfiguration> mServiceConfiguration = new AtomicReference<>();
+    private boolean isPrefetched = false;
 
     public RNAppAuthModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -65,7 +63,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     }
 
     @ReactMethod
-    public void warmUpChromeCustomTab(
+    public void prefetchOnce(
+        final String issuer,
         final String redirectUrl,
         final String clientId,
         final ReadableArray scopes,
@@ -73,13 +72,39 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Boolean dangerouslyAllowInsecureHttpRequests,
         final Promise promise
     ) {
-        if (serviceConfiguration != null) {
-            try {
-                final Context context = this.reactContext;
-                final AuthorizationServiceConfiguration convertedServiceConfiguration = createAuthorizationServiceConfiguration(serviceConfiguration);
-                this.warmUpIntentLatch = new CountDownLatch(1);
-                this.warmUpExecutor = Executors.newSingleThreadExecutor();
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
 
+        if (serviceConfiguration != null && mServiceConfiguration.get() == null) {
+            try {
+                mServiceConfiguration.set(createAuthorizationServiceConfiguration(serviceConfiguration));
+            } catch (Exception e) {
+                promise.reject("RNAppAuth Error", "Failed to convert serviceConfiguration", e);
+            }
+        } else if (mServiceConfiguration.get() == null) {
+            final Uri issuerUri = Uri.parse(issuer);
+            AuthorizationServiceConfiguration.fetchFromUrl(
+                    buildConfigurationUriFromIssuer(issuerUri),
+                    new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
+                        public void onFetchConfigurationCompleted(
+                                @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
+                                @Nullable AuthorizationException ex) {
+                            if (ex != null) {
+                                promise.reject("RNAppAuth Error", "Failed to fetch configuration", ex);
+                                return;
+                            }
+                            mServiceConfiguration.set(fetchedConfiguration);
+                        }
+                    },
+                    builder
+            );
+        }
+
+        if (!isPrefetched) {
+            try {
+                final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
+                final AuthorizationService warmUpAuthService = new AuthorizationService(this.reactContext, appAuthConfiguration);
+                CountDownLatch warmUpIntentLatch = new CountDownLatch(1);
+                ExecutorService warmUpExecutor = Executors.newSingleThreadExecutor();
                 String scopesString = null;
                 if (scopes != null) {
                     scopesString = this.arrayToString(scopes);
@@ -87,7 +112,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
                 AuthorizationRequest.Builder warmUpRequestBuilder =
                         new AuthorizationRequest.Builder(
-                                convertedServiceConfiguration,
+                                mServiceConfiguration.get(),
                                 clientId,
                                 ResponseTypeValues.CODE,
                                 Uri.parse(redirectUrl)
@@ -97,22 +122,18 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                     warmUpRequestBuilder.setScope(scopesString);
                 }
 
-                final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
-                final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
-                final AuthorizationService warmUpAuthService = new AuthorizationService(this.reactContext, appAuthConfiguration);
                 final AuthorizationRequest warmUpAuthRequest = warmUpRequestBuilder.build();
 
-                this.warmUpExecutor.execute(() -> {
+                warmUpExecutor.execute(() -> {
                     CustomTabsIntent.Builder intentBuilder = warmUpAuthService.createCustomTabsIntentBuilder(warmUpAuthRequest.toUri());
-                    this.warmUpIntent.set(intentBuilder.build());
-                    this.warmUpIntentLatch.countDown();
+                    CustomTabsIntent warmUpIntent = intentBuilder.build();
+                    warmUpIntentLatch.countDown();
                 });
-                promise.resolve(true);
-            } catch(Exception e) {
+                isPrefetched = true;
+                promise.resolve(isPrefetched);
+            } catch (Exception e) {
                 promise.reject("RNAppAuth Warm Up Error", "Failed to warm up Chrome Custom Tab", e);
             }
-        } else {
-            promise.reject("RNAppAuth Warm Up Error", "Failed to warm up Chrome Custom Tab: ServiceConfiguration missing");
         }
     }
 
@@ -143,10 +164,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         this.clientSecret = clientSecret;
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
-        if (serviceConfiguration != null) {
+        if (serviceConfiguration != null || mServiceConfiguration.get() != null) {
             try {
+                final AuthorizationServiceConfiguration serviceConfig = mServiceConfiguration.get() != null ? mServiceConfiguration.get() : createAuthorizationServiceConfiguration(serviceConfiguration);
                 authorizeWithConfiguration(
-                        createAuthorizationServiceConfiguration(serviceConfiguration),
+                        serviceConfig,
                         appAuthConfiguration,
                         clientId,
                         scopes,
@@ -169,6 +191,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 return;
                             }
 
+                            mServiceConfiguration.set(fetchedConfiguration);
+                            
                             authorizeWithConfiguration(
                                     fetchedConfiguration,
                                     appAuthConfiguration,
@@ -214,10 +238,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         this.additionalParametersMap = additionalParametersMap;
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
-        if (serviceConfiguration != null) {
+        if (serviceConfiguration != null || mServiceConfiguration.get() != null) {
             try {
+                final AuthorizationServiceConfiguration serviceConfig = mServiceConfiguration.get() != null ? mServiceConfiguration.get() : createAuthorizationServiceConfiguration(serviceConfiguration);
                 refreshWithConfiguration(
-                        createAuthorizationServiceConfiguration(serviceConfiguration),
+                        serviceConfig,
                         appAuthConfiguration,
                         refreshToken,
                         clientId,
@@ -232,7 +257,6 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             }
         } else {
             final Uri issuerUri = Uri.parse(issuer);
-            // @TODO: Refactor to avoid hitting IDP endpoint on refresh, reuse fetchedConfiguration if possible.
             AuthorizationServiceConfiguration.fetchFromUrl(
                     buildConfigurationUriFromIssuer(issuerUri),
                     new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
@@ -243,6 +267,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 promise.reject("RNAppAuth Error", "Failed to fetch configuration", ex);
                                 return;
                             }
+
+                            mServiceConfiguration.set(fetchedConfiguration);
 
                             refreshWithConfiguration(
                                     fetchedConfiguration,

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -75,6 +75,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             try {
                 mServiceConfiguration.set(createAuthorizationServiceConfiguration(serviceConfiguration));
                 isPrefetched = true;
+                fetchConfigurationLatch.countDown();
             } catch (Exception e) {
                 promise.reject("RNAppAuth Error", "Failed to convert serviceConfiguration", e);
             }

--- a/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
+++ b/android/src/main/java/com/reactlibrary/RNAppAuthModule.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.Nullable;
-import android.support.customtabs.CustomTabsIntent;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -43,8 +42,6 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 public class RNAppAuthModule extends ReactContextBaseJavaModule implements ActivityEventListener {
 
@@ -73,10 +70,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Promise promise
     ) {
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
-
+        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
         if (serviceConfiguration != null && mServiceConfiguration.get() == null) {
             try {
                 mServiceConfiguration.set(createAuthorizationServiceConfiguration(serviceConfiguration));
+                isPrefetched = true;
             } catch (Exception e) {
                 promise.reject("RNAppAuth Error", "Failed to convert serviceConfiguration", e);
             }
@@ -93,47 +91,18 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 return;
                             }
                             mServiceConfiguration.set(fetchedConfiguration);
+                            isPrefetched = true;
+                            fetchConfigurationLatch.countDown();
                         }
                     },
                     builder
             );
         }
-
-        if (!isPrefetched) {
-            try {
-                final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
-                final AuthorizationService warmUpAuthService = new AuthorizationService(this.reactContext, appAuthConfiguration);
-                CountDownLatch warmUpIntentLatch = new CountDownLatch(1);
-                ExecutorService warmUpExecutor = Executors.newSingleThreadExecutor();
-                String scopesString = null;
-                if (scopes != null) {
-                    scopesString = this.arrayToString(scopes);
-                }
-
-                AuthorizationRequest.Builder warmUpRequestBuilder =
-                        new AuthorizationRequest.Builder(
-                                mServiceConfiguration.get(),
-                                clientId,
-                                ResponseTypeValues.CODE,
-                                Uri.parse(redirectUrl)
-                        );
-
-                if (scopesString != null) {
-                    warmUpRequestBuilder.setScope(scopesString);
-                }
-
-                final AuthorizationRequest warmUpAuthRequest = warmUpRequestBuilder.build();
-
-                warmUpExecutor.execute(() -> {
-                    CustomTabsIntent.Builder intentBuilder = warmUpAuthService.createCustomTabsIntentBuilder(warmUpAuthRequest.toUri());
-                    CustomTabsIntent warmUpIntent = intentBuilder.build();
-                    warmUpIntentLatch.countDown();
-                });
-                isPrefetched = true;
-                promise.resolve(isPrefetched);
-            } catch (Exception e) {
-                promise.reject("RNAppAuth Warm Up Error", "Failed to warm up Chrome Custom Tab", e);
-            }
+        try {
+            fetchConfigurationLatch.await();
+            promise.resolve(isPrefetched);
+        } catch (Exception e) {
+            promise.reject("RNAppAuth Error", "Failed to await fetch configuration", e);
         }
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,8 @@ export interface RefreshConfiguration {
   refreshToken: string;
 }
 
+export function warmUpChromeCustomTab(config: AuthConfiguration): Promise<void>;
+
 export function authorize(config: AuthConfiguration): Promise<AuthorizeResult>;
 
 export function refresh(

--- a/index.d.ts
+++ b/index.d.ts
@@ -18,9 +18,9 @@ export type BaseAuthConfiguration =
     };
 
 interface BuiltInParameters {
-  display?: "page" | "popup" | "touch" | "wap";
+  display?: 'page' | 'popup' | 'touch' | 'wap';
   login_prompt?: string;
-  prompt?: "consent" |"login" | "none" | "select_account";
+  prompt?: 'consent' | 'login' | 'none' | 'select_account';
 }
 
 export type AuthConfiguration = BaseAuthConfiguration & {
@@ -49,7 +49,7 @@ export interface RefreshConfiguration {
   refreshToken: string;
 }
 
-export function warmUpChromeCustomTab(config: AuthConfiguration): Promise<void>;
+export function prefetchOnce(config: AuthConfiguration): Promise<void>;
 
 export function authorize(config: AuthConfiguration): Promise<AuthorizeResult>;
 

--- a/index.js
+++ b/index.js
@@ -41,12 +41,12 @@ export const warmUpChromeCustomTab = ({
       clientId,
       scopes,
       serviceConfiguration,
-      dangerouslyAllowInsecureHttpRequests
+      dangerouslyAllowInsecureHttpRequests,
     ];
 
     RNAppAuth.warmUpChromeCustomTab(...nativeMethodArguments);
   }
-}
+};
 
 export const authorize = ({
   issuer,

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ export const prefetchOnce = async ({
       dangerouslyAllowInsecureHttpRequests,
     ];
 
-    await RNAppAuth.prefetchOnce(...nativeMethodArguments);
+    RNAppAuth.prefetchOnce(...nativeMethodArguments);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const validateClientId = clientId =>
 const validateRedirectUrl = redirectUrl =>
   invariant(typeof redirectUrl === 'string', 'Config error: redirectUrl must be a string');
 
-export const prefetchOnce = ({
+export const prefetchOnce = async ({
   issuer,
   redirectUrl,
   clientId,
@@ -44,7 +44,7 @@ export const prefetchOnce = ({
       dangerouslyAllowInsecureHttpRequests,
     ];
 
-    RNAppAuth.prefetchOnce(...nativeMethodArguments);
+    await RNAppAuth.prefetchOnce(...nativeMethodArguments);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -22,9 +22,8 @@ const validateClientId = clientId =>
 const validateRedirectUrl = redirectUrl =>
   invariant(typeof redirectUrl === 'string', 'Config error: redirectUrl must be a string');
 
-
 export const warmUpChromeCustomTab = ({
-  issuer, 
+  issuer,
   redirectUrl,
   clientId,
   scopes,
@@ -35,7 +34,7 @@ export const warmUpChromeCustomTab = ({
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);
     validateRedirectUrl(redirectUrl);
-  
+
     const nativeMethodArguments = [
       redirectUrl,
       clientId,

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const validateClientId = clientId =>
 const validateRedirectUrl = redirectUrl =>
   invariant(typeof redirectUrl === 'string', 'Config error: redirectUrl must be a string');
 
-export const warmUpChromeCustomTab = ({
+export const prefetchOnce = ({
   issuer,
   redirectUrl,
   clientId,
@@ -36,6 +36,7 @@ export const warmUpChromeCustomTab = ({
     validateRedirectUrl(redirectUrl);
 
     const nativeMethodArguments = [
+      issuer,
       redirectUrl,
       clientId,
       scopes,
@@ -43,7 +44,7 @@ export const warmUpChromeCustomTab = ({
       dangerouslyAllowInsecureHttpRequests,
     ];
 
-    RNAppAuth.warmUpChromeCustomTab(...nativeMethodArguments);
+    RNAppAuth.prefetchOnce(...nativeMethodArguments);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -22,6 +22,32 @@ const validateClientId = clientId =>
 const validateRedirectUrl = redirectUrl =>
   invariant(typeof redirectUrl === 'string', 'Config error: redirectUrl must be a string');
 
+
+export const warmUpChromeCustomTab = ({
+  issuer, 
+  redirectUrl,
+  clientId,
+  scopes,
+  serviceConfiguration,
+  dangerouslyAllowInsecureHttpRequests = false,
+}) => {
+  if (Platform.OS === 'android') {
+    validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
+    validateClientId(clientId);
+    validateRedirectUrl(redirectUrl);
+  
+    const nativeMethodArguments = [
+      redirectUrl,
+      clientId,
+      scopes,
+      serviceConfiguration,
+      dangerouslyAllowInsecureHttpRequests
+    ];
+
+    RNAppAuth.warmUpChromeCustomTab(...nativeMethodArguments);
+  }
+}
+
 export const authorize = ({
   issuer,
   redirectUrl,


### PR DESCRIPTION
Hey there, please have a look at this.

What it does:
Adding a method to prefetch once and reuse the AuthorizationServiceConfig with discovery mode.
It takes at least 50% less time to start up the Chrome Custom Tab on Android in Emulator if you call this in componentDidMount.
On device it's almost instant with this addition.

Usage in JS:
`import { prefetchOnce } from "react-native-app-auth";`

`componentDidMount() {
        prefetchOnce(authConfig);
}`

Edit: Refactored the original PR
Edit2: I also have a branch which adapts the example to use prefetchOnce
Edit3: Had a look at iOS, I think we don't have to do anything there. The SFSafariViewController opens instantly no matter if it has to discover or not