### PR TITLE
Uniform auth session handling (iOS)

### DIFF
--- a/Example/ios/AppAuthExample/AppDelegate.h
+++ b/Example/ios/AppAuthExample/AppDelegate.h
@@ -8,8 +8,10 @@
  */
 
 #import <UIKit/UIKit.h>
+#import <RNAppAuth/RNAppAuthAuthorizationFlowManager.h>
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, RNAppAuthAuthorizationFlowManager>
 @property (nonatomic, strong, nullable) UIWindow *window;
+@property(nonatomic, weak)id<RNAppAuthAuthorizationFlowManagerDelegate>authorizationFlowManagerDelegate;
 @end
 

--- a/Example/ios/AppAuthExample/AppDelegate.m
+++ b/Example/ios/AppAuthExample/AppDelegate.m
@@ -10,19 +10,8 @@
 #import "AppDelegate.h"
 #import <React/RCTBundleURLProvider.h>
 #import <React/RCTRootView.h>
-#import <AppAuth/AppAuth.h>
-#import <RNAppAuth/RNAppAuthAuthorizationFlowManager.h>
-
-@interface AppDelegate()<RNAppAuthAuthorizationFlowManager> {
-  id <OIDAuthorizationFlowSession> _currentSession;
-}
-@end
 
 @implementation AppDelegate
-
--(void)setCurrentAuthorizationFlowSession:(id<OIDAuthorizationFlowSession>)session {
-  _currentSession = session;
-}
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
@@ -45,9 +34,7 @@
 }
 
 - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
-  BOOL shouldOpenUrl = [_currentSession resumeAuthorizationFlowWithURL:url];
-  _currentSession = nil;
-  return shouldOpenUrl;
+  return [self.authorizationFlowManagerDelegate resumeExternalUserAgentFlowWithURL:url];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ AppAuth supports three options for dependency management.
    With [CocoaPods](https://guides.cocoapods.org/using/getting-started.html), add the following line to
    your `Podfile`:
 
-       pod 'AppAuth', '>= 0.91'
+       pod 'AppAuth', '>= 0.94'
 
-   Then run `pod install`. Note that version 0.91 is the first of the library to support iOS 11.
+   Then run `pod install`. Note that version 0.94 is the first of the library to support iOS 11.
 
 2. **Carthage**
 
@@ -264,39 +264,21 @@ authorization flow from the redirect. Follow these steps:
 
 `RNAppAuth` will call on the given app's delegate via `[UIApplication sharedApplication].delegate`.
 Furthermore, `RNAppAuth` expects the delegate instance to conform to the protocol `RNAppAuthAuthorizationFlowManager`.
-Make `AppDelegate` conform to `RNAppAuthAuthorizationFlowManager`:
+Make `AppDelegate` conform to `RNAppAuthAuthorizationFlowManager` with the following changes to `AppDelegate.h`:
 
 ```diff
-+ // Depending on build configurations, import either with:
-+@import RNAppAuth;
-+ // or:
-+import <AppAuth/AppAuth.h>
-+import "RNAppAuthAuthorizationFlowManager.h"
-
-+ @interface AppDelegate()<RNAppAuthAuthorizationFlowManager> {
-+  id <OIDAuthorizationFlowSession> _currentSession;
-+ }
-+ @end
-```
-
-Implement the required method of `RNAppAuthAuthorizationFlowManager` in `AppDelegate`:
-
-```diff
-+ -(void)setCurrentAuthorizationFlowSession:(id<OIDAuthorizationFlowSession>)session {
-+    // retain session for further use
-+    _currentSession = session;
-+ }
++#import <RNAppAuth/RNAppAuthAuthorizationFlowManager.h>
++@interface AppDelegate : UIResponder <UIApplicationDelegate, RNAppAuthAuthorizationFlowManager>
++@property(nonatomic, weak)id<RNAppAuthAuthorizationFlowManagerDelegate>authorizationFlowManagerDelegate;
 ```
 
 The authorization response URL is returned to the app via the iOS openURL app delegate method, so
 you need to pipe this through to the current authorization session (created in the previous
-instruction). Thus, implement the following method from `UIApplicationDelegate` in `AppDelegate`:
+instruction). Thus, implement the following method from `UIApplicationDelegate` in `AppDelegate.m`:
 
 ```diff
 + - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *)options {
-+   BOOL shouldOpenUrl = [_currentSession resumeAuthorizationFlowWithURL:url];
-+   _currentSession = nil;
-+   return shouldOpenUrl;
++ return return [self.authorizationFlowManagerDelegate resumeExternalUserAgentFlowWithURL:url];
 + }
 ```
 
@@ -304,18 +286,17 @@ instruction). Thus, implement the following method from `UIApplicationDelegate` 
 
 The approach mentioned above should also be possible to employ with Swift. In this case one should have to import `RNAppAuth`
 and make `AppDelegate` conform to `RNAppAuthAuthorizationFlowManager`. Note that this has not been tested.
-`AppDelegate` should look something like this:
+`AppDelegate.swift` should look something like this:
 
 ```swift
 @import RNAppAuth
 class AppDelegate: UIApplicationDelegate, RNAppAuthAuthorizationFlowManager {
-  private var currentAuthorizationFlow: OIDAuthorizationFlowSession?
+  public weak var authorizationFlowManagerDelegate: RNAppAuthAuthorizationFlowManagerDelegate?
   func application(
       _ app: UIApplication,
       open url: URL,
       options: [UIApplicationOpenURLOptionsKey: Any] = [:]) -> Bool {
-      defer { currentAuthorizationFlow = nil }
-      return currentAuthorizationFlow?.resumeAuthorizationFlow(with: url) ?? false
+      return authorizationFlowManagerDelegate?.resumeExternalUserAgentFlowWithURL(with: url) ?? false
   }
 }
 ```

--- a/ios/RNAppAuth.podspec
+++ b/ios/RNAppAuth.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency "React"
-  s.dependency "AppAuth"
+  s.dependency "AppAuth", "0.94.0"
 end

--- a/ios/RNAppAuthAuthorizationFlowManager.h
+++ b/ios/RNAppAuthAuthorizationFlowManager.h
@@ -1,7 +1,7 @@
 #import <Foundation/Foundation.h>
-#import <AppAuth/AppAuth.h>
+#import "RNAppAuthAuthorizationFlowManagerDelegate.h"
 
 @protocol RNAppAuthAuthorizationFlowManager <NSObject>
 @required
--(void)setCurrentAuthorizationFlowSession:(id<OIDAuthorizationFlowSession>)session;
+@property(nonatomic, weak)id<RNAppAuthAuthorizationFlowManagerDelegate>authorizationFlowManagerDelegate;
 @end

--- a/ios/RNAppAuthAuthorizationFlowManagerDelegate.h
+++ b/ios/RNAppAuthAuthorizationFlowManagerDelegate.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+
+@protocol RNAppAuthAuthorizationFlowManagerDelegate <NSObject>
+@required
+-(BOOL)resumeExternalUserAgentFlowWithURL:(NSURL *)url;
+@end


### PR DESCRIPTION
As `application:openURL:options:` is only called on iOS version < 11, the `_currentSession` was not cleared when code was execute on iOS 11. This PR addresses the issue by retaining the session in the `RNAppAuth` instance. Clearing the session is now handled uniformly in the completion handler where the auth state is provided.

`application:openURL:options:` is handled via a delegate pattern instead, which also reduces exposure of app auth related classes. 

Also, this PR bumps the AppAuth dependency to `0.94.0`, and makes use of the newer types in order to get rid of deprecation warnings.