### PR TITLE
Feature: Add Azure Active Directory Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ These providers are OpenID compliant, which means you can use [autodiscovery](ht
   ([Example configuration](#google))
 * [Okta](https://developer.okta.com) ([Example configuration](#okta))
 * [Keycloak](http://www.keycloak.org/) ([Example configuration](#keycloak))
+* [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory) ([Example configuration](#azure-active-directory))
 
 ### Tested OAuth2 providers:
 
@@ -210,7 +211,7 @@ AppAuth supports three options for dependency management.
    With [CocoaPods](https://guides.cocoapods.org/using/getting-started.html), add the following line to
    your `Podfile`:
 
-       pod 'AppAuth', '>= 0.91'
+       pod 'AppAuth', '>= 0.94'
 
    Then run `pod install`. Note that version 0.91 is the first of the library to support iOS 11.
 
@@ -574,6 +575,37 @@ const config = {
   clientId: 'web_app',
   redirectUrl: '<YOUR_REDIRECT_SCHEME>:/callback'
   scopes: ['openid', 'profile']
+};
+
+// Log in to get an authentication token
+const authState = await authorize(config);
+
+// Refresh token
+const refreshedState = await refresh(config, {
+  refreshToken: authState.refreshToken,
+});
+```
+
+### Azure Active Directory
+
+Azure Active Directory [does not specify a revocation endpoint](https://docs.microsoft.com/en-us/azure/active-directory/active-directory-configurable-token-lifetimes#access-tokens) because the access token are not revokable. Therefore `revoke` functionality doesn't work.
+
+See the [Azure docs on requesting an access token](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code#request-an-authorization-code) for more info on additional parameters.
+
+Please Note:
+  * The [Azure docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-code#request-an-authorization-code) recommend `'urn:ietf:wg:oauth:2.0:oob'` as the `redirectUrl`.
+  * `Scopes` is ignored.
+  * `additionalParameters.resource` may be required based on the tenant settings.
+
+```js
+const config = {
+  issuer: 'https://login.microsoftonline.com/your-tenant-id',
+  clientId: 'your-client-id',
+  redirectUrl: 'urn:ietf:wg:oauth:2.0:oob',
+  scopes: [], // ignored by Azure AD
+  additionalParameters: {
+    resource: 'your-resource'
+  }
 };
 
 // Log in to get an authentication token


### PR DESCRIPTION
Adds an example for Azure Active Directory and updates example podfile to use AppAuth >=0.94 for Azure AD compatibility.

Closes #153 