### PR TITLE
Support making nonce nullable

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -362,7 +362,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             @Override
             public void onTokenRequestCompleted(@Nullable TokenResponse response, @Nullable AuthorizationException ex) {
                 if (response != null) {
-                    WritableMap map = tokenResponseToMap(response, null);
+                    WritableMap map = tokenResponseToMap(response);
                     promise.resolve(map);
                 } else {
                     promise.reject("RNAppAuth Error", "Failed refresh token");
@@ -392,6 +392,42 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             strBuilder.append(array.getString(i));
         }
         return strBuilder.toString();
+    }
+
+/*
+     * Read raw token response into a React Native map to be passed down the bridge
+     */
+    private WritableMap tokenResponseToMap(TokenResponse response) {
+        WritableMap map = Arguments.createMap();
+
+        map.putString("accessToken", response.accessToken);
+
+        if (response.accessTokenExpirationTime != null) {
+            Date expirationDate = new Date(response.accessTokenExpirationTime);
+            SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US);
+            formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+            String expirationDateString = formatter.format(expirationDate);
+            map.putString("accessTokenExpirationDate", expirationDateString);
+        }
+
+        WritableMap additionalParametersMap = Arguments.createMap();
+
+        if (!response.additionalParameters.isEmpty()) {
+
+            Iterator<String> iterator = response.additionalParameters.keySet().iterator();
+
+            while(iterator.hasNext()) {
+                String key = iterator.next();
+                additionalParametersMap.putString(key, response.additionalParameters.get(key));
+            }
+        }
+
+        map.putMap("additionalParameters", additionalParametersMap);
+        map.putString("idToken", response.idToken);
+        map.putString("refreshToken", response.refreshToken);
+        map.putString("tokenType", response.tokenType);
+
+        return map;
     }
 
     /*

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -207,7 +207,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         if (requestCode == 0) {
-            AuthorizationResponse response = AuthorizationResponse.fromIntent(data);
+            final AuthorizationResponse response = AuthorizationResponse.fromIntent(data);
             AuthorizationException exception = AuthorizationException.fromIntent(data);
             if (exception != null) {
                 promise.reject("RNAppAuth Error", "Failed to authenticate", exception);
@@ -229,7 +229,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 public void onTokenRequestCompleted(
                         TokenResponse resp, AuthorizationException ex) {
                     if (resp != null) {
-                        WritableMap map = tokenResponseToMap(resp);
+                        WritableMap map = tokenResponseToMap(resp, response.additionalParameters);
                         authorizePromise.resolve(map);
                     } else {
                         promise.reject("RNAppAuth Error", "Failed exchange token", ex);
@@ -362,7 +362,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             @Override
             public void onTokenRequestCompleted(@Nullable TokenResponse response, @Nullable AuthorizationException ex) {
                 if (response != null) {
-                    WritableMap map = tokenResponseToMap(response);
+                    WritableMap map = tokenResponseToMap(response, null);
                     promise.resolve(map);
                 } else {
                     promise.reject("RNAppAuth Error", "Failed refresh token");
@@ -397,7 +397,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     /*
      * Read raw token response into a React Native map to be passed down the bridge
      */
-    private WritableMap tokenResponseToMap(TokenResponse response) {
+    private WritableMap tokenResponseToMap(TokenResponse response, Map<String, String> responseAdditionalParameters) {
         WritableMap map = Arguments.createMap();
 
         map.putString("accessToken", response.accessToken);
@@ -412,13 +412,23 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         WritableMap additionalParametersMap = Arguments.createMap();
 
-        if (!response.additionalParameters.isEmpty()) {
+        if (!responseAdditionalParameters.isEmpty()) {
 
-            Iterator<String> iterator = response.additionalParameters.keySet().iterator();
+            Iterator<String> iterator = responseAdditionalParameters.keySet().iterator();
 
             while(iterator.hasNext()) {
                 String key = iterator.next();
-                additionalParametersMap.putString(key, response.additionalParameters.get(key));
+                additionalParametersMap.putString(key, responseAdditionalParameters.get(key));
+            }
+        }
+
+        if(!this.additionalParametersMap.isEmpty()) {
+
+            Iterator<String> iterator = this.additionalParametersMap.keySet().iterator();
+
+            while(iterator.hasNext()) {
+                String key = iterator.next();
+                additionalParametersMap.putString(key, this.additionalParametersMap.get(key));
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ export const authorize = ({
   clientId,
   clientSecret,
   scopes,
+  useNonce = true,
   additionalParameters,
   serviceConfiguration,
   dangerouslyAllowInsecureHttpRequests = false,
@@ -48,6 +49,10 @@ export const authorize = ({
   ];
   if (Platform.OS === 'android') {
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
+  } else {
+    // add a new useNonce param on iOS to support making it optional
+    const nonceParamIndex = 5;
+    nativeMethodArguments.splice(nonceParamIndex, 0, useNonce);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);

--- a/index.spec.js
+++ b/index.spec.js
@@ -32,6 +32,7 @@ describe('AppAuth', () => {
     additionalParameters: { hello: 'world' },
     serviceConfiguration: null,
     scopes: ['my-scope'],
+    useNonce: true,
   };
 
   describe('authorize', () => {
@@ -86,6 +87,7 @@ describe('AppAuth', () => {
         config.clientId,
         config.clientSecret,
         config.scopes,
+        config.useNonce,
         config.additionalParameters,
         config.serviceConfiguration
       );

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -41,6 +41,7 @@ RCT_REMAP_METHOD(authorize,
                                 clientId: clientId
                             clientSecret: clientSecret
                                   scopes: scopes
+                                useNonce: useNonce
                     additionalParameters: additionalParameters
                                  resolve: resolve
                                   reject: reject];
@@ -56,6 +57,7 @@ RCT_REMAP_METHOD(authorize,
                                                                                         clientId: clientId
                                                                                     clientSecret: clientSecret
                                                                                           scopes: scopes
+                                                                                        useNonce: useNonce
                                                                             additionalParameters: additionalParameters
                                                                                          resolve: resolve
                                                                                           reject: reject];
@@ -134,6 +136,7 @@ RCT_REMAP_METHOD(refresh,
                           clientId: (NSString *) clientId
                       clientSecret: (NSString *) clientSecret
                             scopes: (NSArray *) scopes
+                          useNonce: (BOOL *) useNonce
               additionalParameters: (NSDictionary *_Nullable) additionalParameters
                            resolve: (RCTPromiseResolveBlock) resolve
                             reject: (RCTPromiseRejectBlock)  reject
@@ -144,6 +147,7 @@ RCT_REMAP_METHOD(refresh,
                                                   clientId:clientId
                                               clientSecret:clientSecret
                                                     scopes:scopes
+                                                  useNonce:useNonce
                                                redirectURL:[NSURL URLWithString:redirectUrl]
                                               responseType:OIDResponseTypeCode
                                       additionalParameters:additionalParameters];

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -28,6 +28,7 @@ RCT_REMAP_METHOD(authorize,
                  clientId: (NSString *) clientId
                  clientSecret: (NSString *) clientSecret
                  scopes: (NSArray *) scopes
+                 useNonce: (BOOL *) useNonce
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  resolve: (RCTPromiseResolveBlock) resolve

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -152,7 +152,7 @@ RCT_REMAP_METHOD(refresh,
   // generates the code_challenge per spec https://tools.ietf.org/html/rfc7636#section-4.2
   // code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
   // NB. the ASCII conversion on the code_verifier entropy was done at time of generation.
-  NSData *sha256Verifier = [OIDTokenUtilities sha265:codeVerifier];
+  NSData *sha256Verifier = [OIDTokenUtilities sha255:codeVerifier];
   return [OIDTokenUtilities encodeBase64urlNoPadding:sha256Verifier];
 }
 

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -204,7 +204,8 @@ RCT_REMAP_METHOD(refresh,
                                                        typeof(self) strongSelf = weakSelf;
                                                        strongSelf->_currentSession = nil;
                                                        if (authState) {
-                                                           resolve([self formatResponse:authState.lastTokenResponse]);
+                                                           resolve([self formatResponse:authState.lastTokenResponse
+                                                               withAdditionalParameters:authState.lastAuthorizationResponse.additionalParameters]);
                                                        } else {
                                                            reject(@"RNAppAuth Error", [error localizedDescription], error);
                                                        }
@@ -260,6 +261,26 @@ RCT_REMAP_METHOD(refresh,
     return @{@"accessToken": response.accessToken ? response.accessToken : @"",
              @"accessTokenExpirationDate": response.accessTokenExpirationDate ? [dateFormat stringFromDate:response.accessTokenExpirationDate] : @"",
              @"additionalParameters": response.additionalParameters,
+             @"idToken": response.idToken ? response.idToken : @"",
+             @"refreshToken": response.refreshToken ? response.refreshToken : @"",
+             @"tokenType": response.tokenType ? response.tokenType : @"",
+             };
+}
+
+/*
+ * Take raw OIDTokenResponse and additional paramaeters from an OIDAuthorizationResponse
+ *  and turn them into an extended token response format to pass to JavaScript caller
+ */
+- (NSDictionary*)formatResponse: (OIDTokenResponse*) response
+       withAdditionalParameters:(NSDictionary*) params{
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    dateFormat.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
+    [dateFormat setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+    [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+    
+    return @{@"accessToken": response.accessToken ? response.accessToken : @"",
+             @"accessTokenExpirationDate": response.accessTokenExpirationDate ? [dateFormat stringFromDate:response.accessTokenExpirationDate] : @"",
+             @"additionalParameters": params,
              @"idToken": response.idToken ? response.idToken : @"",
              @"refreshToken": response.refreshToken ? response.refreshToken : @"",
              @"tokenType": response.tokenType ? response.tokenType : @"",

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -152,7 +152,7 @@ RCT_REMAP_METHOD(refresh,
   // generates the code_challenge per spec https://tools.ietf.org/html/rfc7636#section-4.2
   // code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
   // NB. the ASCII conversion on the code_verifier entropy was done at time of generation.
-  NSData *sha256Verifier = [OIDTokenUtilities sha255:codeVerifier];
+  NSData *sha256Verifier = [OIDTokenUtilities sha256:codeVerifier];
   return [OIDTokenUtilities encodeBase64urlNoPadding:sha256Verifier];
 }
 


### PR DESCRIPTION
AppAuth-iOS worked correctly with [AWS Cognito](https://aws.amazon.com/cognito/) up until its 0.92 release, later they added support that added support for a nonce parameter. The issue lies in the inabilty of Cognito to handle the nonce parameter (mentioned in their forums [here](https://forums.aws.amazon.com/thread.jspa?messageID=802423&tstart=0)).
There is a comment on the `OIDAuthorizationRequest.h` file from AppAuth-iOS that mentions something about it being nullable:
```
    @param nonce String value used to associate a Client session with an ID Token. Can be set to nil
        if not using OpenID Connect, although pure OAuth servers should ignore params they don't
        understand anyway.
```

The idea here is to add a new optional param `useNonce` that when set to false, tells the iOS implementation to not generate a nonce attribute automatically. This only happens on the iOS implementation, Android does not have this issue.