### PR TITLE
Add a framework search path for Carthage

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,11 @@ AppAuth supports three options for dependency management.
 
        github "openid/AppAuth-iOS" "master"
 
-   Then run `carthage bootstrap`.
+   Then run `carthage update --platform iOS`.
+
+   Drag and drop `AppAuth.framework` from `ios/Carthage/Build/iOS` under `Frameworks` in `Xcode`.
+
+   Add a copy files build step for `AppAuth.framework`: open Build Phases on Xcode, add a new "Cope Files" phase, choose "Frameworks" as destination, add `AppAuth.framework` and ensure "Code Sign on Copy" is checked.
 
 3. **Static Library**
 

--- a/ios/RNAppAuth.xcodeproj/project.pbxproj
+++ b/ios/RNAppAuth.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Carthage/build/iOS";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
@@ -225,6 +226,7 @@
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = "$(SRCROOT)/../../../ios/Carthage/build/iOS";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/188

Adding a framework search path for to fix installing the AppAuth dependency via Carthage

### To Verify
1. Follow the installation instructions for Carthage in the readme
2. Drag and drop the `AppAuth.framework` from `ios/Carthage/Build/iOS` under `Frameworks` in `Xcode`
3. Add a copy files build step for AppAuth.framework as specified here https://github.com/Carthage/Carthage/issues/616#issuecomment-121095995

### Checklist
- [x] include issue number that will be resolved by this PR (e.g. `Fixes #1234`)
- [x] include a summary of the work
- [x] include steps to verify
- [x] update readme (if applicable)
