### PR TITLE
Update android app id

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.rnappauth">
 
 </manifest>
-  

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -1,4 +1,4 @@
-package com.reactlibrary;
+package com.rnappauth;
 
 import android.app.Activity;
 import android.app.PendingIntent;
@@ -16,8 +16,8 @@ import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
-import com.reactlibrary.utils.MapUtils;
-import com.reactlibrary.utils.UnsafeConnectionBuilder;
+import com.rnappauth.utils.MapUtils;
+import com.rnappauth.utils.UnsafeConnectionBuilder;
 
 import net.openid.appauth.AppAuthConfiguration;
 import net.openid.appauth.AuthorizationException;

--- a/android/src/main/java/com/rnappauth/RNAppAuthPackage.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthPackage.java
@@ -1,5 +1,4 @@
-
-package com.reactlibrary;
+package com.rnappauth;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/android/src/main/java/com/rnappauth/utils/MapUtils.java
+++ b/android/src/main/java/com/rnappauth/utils/MapUtils.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.utils;
+package com.rnappauth.utils;
 
 import android.support.annotation.Nullable;
 

--- a/android/src/main/java/com/rnappauth/utils/UnsafeConnectionBuilder.java
+++ b/android/src/main/java/com/rnappauth/utils/UnsafeConnectionBuilder.java
@@ -1,4 +1,4 @@
-package com.reactlibrary.utils;
+package com.rnappauth.utils;
 
 /*
  * Copyright 2016 The AppAuth for Android Authors. All Rights Reserved.


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/183

Libraries created `react-native-create-library` have use the default namespace of `com.reactlibrary` for Android, which can cause conflicts if using multiple libraries with the same name.

Renaming this to `com.rnappauth`

- [x] include issue number that will be resolved by this PR (e.g. `Fixes #1234`)
- [x] include a summary of the work
