### PR TITLE
Bugfix/nonce touchup

### DIFF
--- a/Example/AndroidExample/components/Page.js
+++ b/Example/AndroidExample/components/Page.js
@@ -1,11 +1,22 @@
 // @flow
 
+import React from 'react';
 import styled from 'styled-components/native';
 
-export default styled.ImageBackground.attrs({
-  source: require('../assets/background.jpg')
+const SafeArea = styled.SafeAreaView`
+  flex: 1;
+`;
+
+const Background = styled.ImageBackground.attrs({
+  source: require('../assets/background.jpg'),
 })`
   flex: 1;
   background-color: white;
   padding: 40px 10px 10px 10px;
 `;
+
+export default ({ children }) => (
+  <Background>
+    <SafeArea>{children}</SafeArea>
+  </Background>
+);

--- a/Example/Latest/components/Page.js
+++ b/Example/Latest/components/Page.js
@@ -1,11 +1,22 @@
 // @flow
 
+import React from 'react';
 import styled from 'styled-components/native';
 
-export default styled.ImageBackground.attrs({
+const SafeArea = styled.SafeAreaView`
+  flex: 1;
+`;
+
+const Background = styled.ImageBackground.attrs({
   source: require('../assets/background.jpg')
 })`
   flex: 1;
   background-color: white;
   padding: 40px 10px 10px 10px;
 `;
+
+export default ({ children }) => (
+  <Background>
+    <SafeArea>{children}</SafeArea>
+  </Background>
+);

--- a/Example/iOSCarthageExample/components/Page.js
+++ b/Example/iOSCarthageExample/components/Page.js
@@ -1,11 +1,22 @@
 // @flow
 
+import React from 'react';
 import styled from 'styled-components/native';
 
-export default styled.ImageBackground.attrs({
-  source: require('../assets/background.jpg')
+const SafeArea = styled.SafeAreaView`
+  flex: 1;
+`;
+
+const Background = styled.ImageBackground.attrs({
+  source: require('../assets/background.jpg'),
 })`
   flex: 1;
   background-color: white;
   padding: 40px 10px 10px 10px;
 `;
+
+export default ({ children }) => (
+  <Background>
+    <SafeArea>{children}</SafeArea>
+  </Background>
+);

--- a/Example/iOSPodsExample/components/Page.js
+++ b/Example/iOSPodsExample/components/Page.js
@@ -1,11 +1,22 @@
 // @flow
 
+import React from 'react';
 import styled from 'styled-components/native';
 
-export default styled.ImageBackground.attrs({
-  source: require('../assets/background.jpg')
+const SafeArea = styled.SafeAreaView`
+  flex: 1;
+`;
+
+const Background = styled.ImageBackground.attrs({
+  source: require('../assets/background.jpg'),
 })`
   flex: 1;
   background-color: white;
   padding: 40px 10px 10px 10px;
 `;
+
+export default ({ children }) => (
+  <Background>
+    <SafeArea>{children}</SafeArea>
+  </Background>
+);

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 Past documentation: [`3.1`](https://github.com/FormidableLabs/react-native-app-auth/tree/v3.1.0) [`3.0`](https://github.com/FormidableLabs/react-native-app-auth/tree/v3.0.0) [`2.x`](https://github.com/FormidableLabs/react-native-app-auth/tree/v2.0.0) [`1.x`](https://github.com/FormidableLabs/react-native-app-auth/tree/v1.0.1).
 
-
 React Native bridge for [AppAuth-iOS](https://github.com/openid/AppAuth-iOS) and
 [AppAuth-Android](https://github.com/openid/AppAuth-Android) SDKS for communicating with
 [OAuth 2.0](https://tools.ietf.org/html/rfc6749) and
@@ -97,6 +96,7 @@ with optional overrides.
   Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
   `hello=world&foo=bar` to the authorization request.
 * **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. :warning: Can be useful for testing against local server, _should not be used in production._ This setting has no effect on iOS; to enable insecure HTTP requests, add a [NSExceptionAllowsInsecureHTTPLoads exception](https://cocoacasts.com/how-to-add-app-transport-security-exception-domains) to your App Transport Security settings.
+* **useNonce** - (`boolean`) _IOS_ (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers
 
 #### result
 
@@ -682,11 +682,11 @@ First, set up a your user pool in [the AWS console](https://eu-west-1.console.aw
 Now you need to set up your domain name. This will be on the left menu in your pool details page, under App Integration -> Domain Name. What this is depends on your preference. E.g. for AppAuth demo, mine is `https://app-auth-test.auth.eu-west-1.amazoncognito.com` as I chose `app-auth-test` as the domain and `eu-west-1` as the region.
 
 Finally, you need to configure your app client. Go to App Integration -> App Client Settings.
+
 1. Enable your newly created user pool under Enabled Identity Providers.
 2. Add the callback url (must be same as in your config, e.g. `com.myclientapp://myclient/redirect`)
 3. Enable the Authorization code grant
 4. Enable openid scope
-
 
 ```js
 const config = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   redirectUrl: string;
   additionalParameters?: BuiltInParameters & { [name: string]: string };
   dangerouslyAllowInsecureHttpRequests?: boolean;
+  useNonce?: boolean;
 };
 
 export interface AuthorizeResult {

--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ export const authorize = ({
     additionalParameters,
     serviceConfiguration,
   ];
+
   if (Platform.OS === 'android') {
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
   }

--- a/index.js
+++ b/index.js
@@ -49,10 +49,10 @@ export const authorize = ({
   ];
   if (Platform.OS === 'android') {
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
-  } else {
-    // add a new useNonce param on iOS to support making it optional
-    const nonceParamIndex = 5;
-    nativeMethodArguments.splice(nonceParamIndex, 0, useNonce);
+  }
+
+  if (Platform.OS === 'ios') {
+    nativeMethodArguments.push(useNonce);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);

--- a/index.spec.js
+++ b/index.spec.js
@@ -87,9 +87,9 @@ describe('AppAuth', () => {
         config.clientId,
         config.clientSecret,
         config.scopes,
-        config.useNonce,
         config.additionalParameters,
-        config.serviceConfiguration
+        config.serviceConfiguration,
+        config.useNonce
       );
     });
 
@@ -267,6 +267,40 @@ describe('AppAuth', () => {
           config.additionalParameters,
           config.serviceConfiguration,
           true
+        );
+      });
+    });
+
+    describe('iOS-specific useNonce parameter', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'ios';
+      });
+
+      it('calls the native wrapper with default value `true`', () => {
+        authorize(config, { refreshToken: 'such-token' });
+        expect(mockAuthorize).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          config.clientSecret,
+          config.scopes,
+          config.additionalParameters,
+          config.serviceConfiguration,
+          true
+        );
+      });
+
+      it('calls the native wrapper with passed value `false`', () => {
+        authorize({ ...config, useNonce: false }, { refreshToken: 'such-token' });
+        expect(mockAuthorize).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          config.clientSecret,
+          config.scopes,
+          config.additionalParameters,
+          config.serviceConfiguration,
+          false
         );
       });
     });

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -152,8 +152,8 @@ RCT_REMAP_METHOD(refresh,
   // generates the code_challenge per spec https://tools.ietf.org/html/rfc7636#section-4.2
   // code_challenge = BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
   // NB. the ASCII conversion on the code_verifier entropy was done at time of generation.
-  NSData *sha256Verifier = [OIDTokenUtilities sha256:codeVerifier];
-  return [OIDTokenUtilities encodeBase64urlNoPadding:sha256Verifier];
+    NSData *sha265Verifier = [OIDTokenUtilities sha265:codeVerifier];
+  return [OIDTokenUtilities encodeBase64urlNoPadding:sha265Verifier];
 }
 
 /*

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -36,9 +36,9 @@ RCT_REMAP_METHOD(authorize,
                  clientId: (NSString *) clientId
                  clientSecret: (NSString *) clientSecret
                  scopes: (NSArray *) scopes
-                 useNonce: (BOOL *) useNonce
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
+                 useNonce: (BOOL *) useNonce
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
@@ -277,7 +277,7 @@ RCT_REMAP_METHOD(refresh,
     dateFormat.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
     [dateFormat setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
-    
+
     return @{@"accessToken": response.accessToken ? response.accessToken : @"",
              @"accessTokenExpirationDate": response.accessTokenExpirationDate ? [dateFormat stringFromDate:response.accessTokenExpirationDate] : @"",
              @"additionalParameters": params,


### PR DESCRIPTION
Touchups to make https://github.com/FormidableLabs/react-native-app-auth/pull/169 releasable.

- [x] add it to the readme
- [x] update typescript definitions
- [x] push native argument
- [x] revert sha265 -> sha256 (the typo was released in `AppAuth-iOS/1.0.0.beta1`, but the recommended version for us is still `AppAuth-iOS/0.94.0`, so using the new method would be a breaking change for us and I'd like to avoid it until the latest AppAuth-iOS release is stable)