### PR TITLE
Add `usePKCE` Flag for Dropbox

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   additionalParameters?: BuiltInParameters & { [name: string]: string };
   dangerouslyAllowInsecureHttpRequests?: boolean;
   useNonce?: boolean;
+  usePKCE?: boolean;
 };
 
 export interface AuthorizeResult {

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ export const authorize = ({
   clientSecret,
   scopes,
   useNonce = true,
+  usePKCE = true,
   additionalParameters,
   serviceConfiguration,
   dangerouslyAllowInsecureHttpRequests = false,
@@ -54,6 +55,7 @@ export const authorize = ({
 
   if (Platform.OS === 'ios') {
     nativeMethodArguments.push(useNonce);
+    nativeMethodArguments.push(usePKCE);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -39,6 +39,7 @@ RCT_REMAP_METHOD(authorize,
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  useNonce: (BOOL *) useNonce
+                 usePKCE: (BOOL *) usePKCE
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
@@ -51,6 +52,7 @@ RCT_REMAP_METHOD(authorize,
                             clientSecret: clientSecret
                                   scopes: scopes
                                 useNonce: useNonce
+                                 usePKCE: usePKCE
                     additionalParameters: additionalParameters
                                  resolve: resolve
                                   reject: reject];
@@ -67,6 +69,7 @@ RCT_REMAP_METHOD(authorize,
                                                                                     clientSecret: clientSecret
                                                                                           scopes: scopes
                                                                                         useNonce: useNonce
+                                                                                         usePKCE: usePKCE
                                                                             additionalParameters: additionalParameters
                                                                                          resolve: resolve
                                                                                           reject: reject];
@@ -165,13 +168,14 @@ RCT_REMAP_METHOD(refresh,
                       clientSecret: (NSString *) clientSecret
                             scopes: (NSArray *) scopes
                           useNonce: (BOOL *) useNonce
+                           usePKCE: (BOOL *) usePKCE
               additionalParameters: (NSDictionary *_Nullable) additionalParameters
                            resolve: (RCTPromiseResolveBlock) resolve
                             reject: (RCTPromiseRejectBlock)  reject
 {
 
-    NSString *codeVerifier = [[self class] generateCodeVerifier];
-    NSString *codeChallenge = [[self class] codeChallengeS256ForVerifier:codeVerifier];
+    NSString *codeVerifier = usePKCE ? [[self class] generateCodeVerifier] : nil;
+    NSString *codeChallenge = usePKCE ? [[self class] codeChallengeS256ForVerifier:codeVerifier] : nil;
     NSString *nonce = useNonce ? [[self class] generateState] : nil;
 
     // builds authentication request
@@ -186,7 +190,7 @@ RCT_REMAP_METHOD(refresh,
                                                      nonce:nonce
                                               codeVerifier:codeVerifier
                                              codeChallenge:codeChallenge
-                                      codeChallengeMethod:OIDOAuthorizationRequestCodeChallengeMethodS256
+                                      codeChallengeMethod: usePKCE ? OIDOAuthorizationRequestCodeChallengeMethodS256 : nil
                                       additionalParameters:additionalParameters];
 
     // performs authentication request
@@ -205,7 +209,7 @@ RCT_REMAP_METHOD(refresh,
                                                        strongSelf->_currentSession = nil;
                                                        if (authState) {
                                                            resolve([self formatResponse:authState.lastTokenResponse
-                                                               withAdditionalParameters:authState.lastAuthorizationResponse.additionalParameters]);
+                                                               withAdditionalParameters:authState.lastTokenResponse.additionalParameters]);
                                                        } else {
                                                            reject(@"RNAppAuth Error", [error localizedDescription], error);
                                                        }


### PR DESCRIPTION
This allows providers like Dropbox who don't support PKCE and go so far as to error is you provide unknown parameters in the OAuth2 request to function correctly.

By specifying `usePKCE: false` in the auth options the `code_challenge` parameter will not be sent to the OAuth2 provider and code verification will not run against the response.

Related to #231 and #169. See comment https://github.com/FormidableLabs/react-native-app-auth/pull/169#issuecomment-431587776 as well.

The redirect URL issue with Dropbox can be resolved using universal links or a redirect service.