### PR TITLE
Add separate issue templates for bugs/feature requests/docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,0 @@
-**Is this a bug, feature request or a request for information?**
-
-**Describe your issue and include steps to reproduce if possible.**

--- a/.github/ISSUE_TEMPLATE/Bug_Report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_Report.md
@@ -1,0 +1,26 @@
+---
+name: ⚠️ Bug/Issue report
+about: Please provide as much detail as possible to help us with a bug or issue.
+---
+
+## Issue
+
+<!-- Please describe your issue here --^ and provide as much detail as you can. -->
+
+---
+
+## Environment
+
+<!-- change `[ ]` to `[x]` to select an option(s) -->
+- **Your Identity Provider**: `e.g. IdentityServer 4 / Okta / Azure`
+- **Platform that you're experiencing the issue on**:
+  - [ ] iOS
+  - [ ] Android
+  - [ ] **iOS** but have not tested behavior on Android
+  - [ ] **Android** but have not tested behavior on iOS
+  - [ ] Both
+- **Are you using Expo, e.g. `ExpoKit`?**
+  - [x] No
+  - [ ] Yes, I've _not_ ejected
+  - [ ] Yes, but I **have** ejected to `ExpoKit`
+  - [ ] Yes, but I **have** ejected to vanilla React Native

--- a/.github/ISSUE_TEMPLATE/Documentstion_Issue.md
+++ b/.github/ISSUE_TEMPLATE/Documentstion_Issue.md
@@ -1,0 +1,8 @@
+---
+name: 📖 Documentation Feedback
+about: Report an issue with the documentation or suggest an improvement.
+---
+
+## Documentation Feedback
+
+Please describe your documentation issue or suggested improvement in detail here and provide links to any pre-existing/relevant documentation.

--- a/.github/ISSUE_TEMPLATE/Documentstion_Issue.md
+++ b/.github/ISSUE_TEMPLATE/Documentstion_Issue.md
@@ -5,4 +5,4 @@ about: Report an issue with the documentation or suggest an improvement.
 
 ## Documentation Feedback
 
-Please describe your documentation issue or suggested improvement in detail here and provide links to any pre-existing/relevant documentation.
+<!-- Please describe your documentation issue or suggested improvement in detail here and provide links to any pre-existing/relevant documentation. -->

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,0 +1,6 @@
+---
+name: 🎁 Feature request
+about: Requesting new features
+---
+
+<!-- Please describe the desired feature, especially detailing the problem it should solve  -->


### PR DESCRIPTION
Credit goes to [React Native Firebase](https://github.com/invertase/react-native-firebase) whose issue templates are 👌and which I took as a starting point.