### PR TITLE
Replace 'compile' with 'implementation' in android/build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "net.openid:appauth:0.7.1"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "net.openid:appauth:0.7.1"
 }


### PR DESCRIPTION
- Fixes #241 
- Replaces the now obsolete 'compile' for build.gradle dependencies with the newer 'implementation'
- Compiling any app that depends on this package should no longer complain about the use of 'compile'
- No updates to tests or readme required, just cleans up a warning.