### PR TITLE
Update AppAuth import

### DIFF
--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -1,5 +1,9 @@
 #import "RNAppAuth.h"
+#if __has_include("<AppAuth/AppAuth.h>")
 #import <AppAuth/AppAuth.h>
+#else
+#import "AppAuth.h"
+#endif
 #import <React/RCTLog.h>
 #import <React/RCTConvert.h>
 #import "RNAppAuthAuthorizationFlowManager.h"


### PR DESCRIPTION
This fix allows AppAuth.h to be imported correctly with and without the `use_frameworks` flag set in `Podfile`. After installing the library, I experienced the behavior mentioned here in https://github.com/FormidableLabs/react-native-app-auth/issues/134 and in https://github.com/FormidableLabs/react-native-app-auth/issues/80. I was able to get my project to build correctly after using the `__has_include` macro. More information on the macro can be found here in the[ gcc docs ](https://clang.llvm.org/docs/LanguageExtensions.html#has-include).

- [ ] include issue number that will be resolved by this PR (e.g. `Fixes #1234`)
- [x] include a summary of the work
- [ ] include steps to verify
- [ ] update tests (if applicable)
- [ ] update readme (if applicable)
- [ ] update typescript definitions (if applicable)
