### PR TITLE
Explicitly add invariant to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "author": "kadi.kraman@formidable.com",
   "license": "MIT",
   "peerDependencies": {
+    "invariant": "^2.2.2",
     "react-native": "^0.50.3"
   },
   "devDependencies": {


### PR DESCRIPTION
invariant should be listed as a peer dependency as well, rather than an assumption that react-native will always have a version of invariant that this module is able to use.

I can create an issue to match this PR if the maintainers would prefer, but it's purely an update to the package.json dependencies that makes it clear where invariant is coming from in production.

- [ ] include issue number that will be resolved by this PR (e.g. `Fixes #1234`)
- [ ] include a summary of the work
- [ ] include steps to verify
- [ ] update tests (if applicable)
- [ ] update readme (if applicable)
- [ ] update typescript definitions (if applicable)
