### PR TITLE
Re-add additional params for backwards compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ This is the result from the auth server
 * **accessTokenExpirationDate** - (`string`) the token expiration date
 * **authorizeAdditionalParameters** - (`Object`) additional url parameters from the authorizationEndpoint response.
 * **tokenAdditionalParameters** - (`Object`) additional url parameters from the tokenEndpoint response.
+* **additionalParameters** - (`Object`)  :warning:  _DEPRECATED_ legacy implementation. Will be removed in a future release. Returns just `tokenAdditionalParameters` for Android and `authorizeAdditionalParameters` on iOS
 * **idToken** - (`string`) the id token
 * **refreshToken** - (`string`) the refresh token
 * **tokenType** - (`string`) the token type, e.g. Bearer

--- a/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
@@ -70,6 +70,7 @@ public final class TokenResponseFactory {
         map.putString("accessToken", response.accessToken);
         map.putMap("authorizeAdditionalParameters", createAdditionalParametersMap(authResponse.additionalParameters));
         map.putMap("tokenAdditionalParameters", createAdditionalParametersMap(response.additionalParameters));
+        map.putMap("additionalParameters", createAdditionalParametersMap(response.additionalParameters)); // DEPRECATED
         map.putString("idToken", response.idToken);
         map.putString("refreshToken", response.refreshToken);
         map.putString("tokenType", response.tokenType);

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -290,6 +290,7 @@ RCT_REMAP_METHOD(refresh,
              @"accessTokenExpirationDate": response.accessTokenExpirationDate ? [dateFormat stringFromDate:response.accessTokenExpirationDate] : @"",
              @"authorizeAdditionalParameters": authResponse.additionalParameters,
              @"tokenAdditionalParameters": response.additionalParameters,
+             @"additionalParameters": authResponse.additionalParameters, /* DEPRECATED */
              @"idToken": response.idToken ? response.idToken : @"",
              @"refreshToken": response.refreshToken ? response.refreshToken : @"",
              @"tokenType": response.tokenType ? response.tokenType : @"",


### PR DESCRIPTION
Re-adding additional parameters with a deprecation warning for backwards compatibility.

This is so we could release https://github.com/FormidableLabs/react-native-app-auth/pull/232 without a major version bump.