### PR TITLE
Fix null response for 'scope'

### DIFF
--- a/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
@@ -1,5 +1,7 @@
 package com.rnappauth.utils;
 
+import android.text.TextUtils;
+
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
@@ -29,7 +31,7 @@ public final class TokenResponseFactory {
 
     private static final WritableArray createScopeArray(String scope) {
         WritableArray scopeArray = Arguments.createArray();
-        if (!scope.isEmpty()) {
+        if (!TextUtils.isEmpty(scope)) {
             String[] scopesArray = scope.split(" ");
 
             for( int i = 0; i < scopesArray.length - 1; i++)


### PR DESCRIPTION
If the authResponse does not include a 'scope' parameter, the app crashes on android as it parses the response.  This restores the behavior that existed before 4.0, where a missing scope would be just fine.  Since you might not have control over the server, it would be nice to make this more tolerant to missing fields (like it is on IOS)
