### PR TITLE
[Help Needed] Configure client authentication strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ with optional overrides.
 * **additionalParameters** - (`object`) additional parameters that will be passed in the authorization request.
   Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
   `hello=world&foo=bar` to the authorization request.
+* **clientAuthMethod** - (string) Client Authentication Method. Can be either `basic` (default) for [Basic Authentication](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/ClientSecretBasic.java) or `post` for [HTTP POST body Authentication](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/ClientSecretPost.java)
 * **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. :warning: Can be useful for testing against local server, _should not be used in production._ This setting has no effect on iOS; to enable insecure HTTP requests, add a [NSExceptionAllowsInsecureHTTPLoads exception](https://cocoacasts.com/how-to-add-app-transport-security-exception-domains) to your App Transport Security settings.
 * **customHeaders** - (`object`) _ANDROID_ you can specify custom headers to pass during authorize request and/or token request.
   * **authorize** - (`{ [key: string]: value }`) headers to be passed during authorization request.

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   scopes: string[];
   redirectUrl: string;
   additionalParameters?: BuiltInParameters & { [name: string]: string };
+  clientAuthMethod?: 'basic' | 'post';
   dangerouslyAllowInsecureHttpRequests?: boolean;
   customHeaders?: CustomHeaders;
   useNonce?: boolean;

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ export const authorize = ({
   usePKCE = true,
   additionalParameters,
   serviceConfiguration,
+  clientAuthMethod = 'basic',
   dangerouslyAllowInsecureHttpRequests = false,
   customHeaders,
 }) => {
@@ -78,6 +79,7 @@ export const authorize = ({
   ];
 
   if (Platform.OS === 'android') {
+    nativeMethodArguments.push(clientAuthMethod);
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
   }
@@ -99,6 +101,7 @@ export const refresh = (
     scopes,
     additionalParameters,
     serviceConfiguration,
+    clientAuthMethod = 'basic',
     dangerouslyAllowInsecureHttpRequests = false,
     customHeaders,
   },
@@ -123,6 +126,7 @@ export const refresh = (
   ];
 
   if (Platform.OS === 'android') {
+    nativeMethodArguments.push(clientAuthMethod);
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
   }

--- a/index.spec.js
+++ b/index.spec.js
@@ -165,6 +165,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             false,
             config.customHeaders
           );
@@ -180,6 +181,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             false,
             config.customHeaders
           );
@@ -195,6 +197,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             true,
             config.customHeaders
           );
@@ -214,6 +217,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             false,
             customHeaders
           );
@@ -306,6 +310,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             false,
             config.customHeaders
           );
@@ -325,6 +330,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             false,
             config.customHeaders
           );
@@ -344,6 +350,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             true,
             config.customHeaders
           );
@@ -363,6 +370,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.clientAuthMethod,
             false,
             customHeaders
           );

--- a/index.spec.js
+++ b/index.spec.js
@@ -30,6 +30,7 @@ describe('AppAuth', () => {
     clientId: 'test-clientId',
     clientSecret: 'test-clientSecret',
     additionalParameters: { hello: 'world' },
+    clientAuthMethod: 'post',
     serviceConfiguration: null,
     scopes: ['my-scope'],
     useNonce: true,


### PR DESCRIPTION
- [X] include issue number that will be resolved by this PR (e.g. `Fixes #1234`)
- [X] include a summary of the work
- [X] include steps to verify
- [X] update tests (if applicable)
- [X] update readme (if applicable)
- [X] update typescript definitions (if applicable)

Closes: #271

## Summary

This patch introduces a `clientAuthMethod` flag in both `authroize` and `refresh` methods that utilizes both ClientSecretBasic, a class used for secret exchange with basic authentication (default), and ClientSecretPost, which send authentication credentials via the HTTP POST body.

This PR does not break the default behavior. 

**This feature is currently for Android as I do not have Mac to verify that this is indeed a case for apple devices.**

## Steps to verify

1. Verify that the examples are still working as expected, since this patch will not break the existing functionality.
 2. Set the `clientAuthMethod` to `post` in the configuration object and verify (using a packet sniffer or the logs of the server) that the credentials are exchanged using the HTTP body.

 