### PR TITLE
Update Readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ correct Android Support library version to your project:
    of the appcompat libraries and need to upgdrade:
    ```
    dependencies {
-     compile "com.android.support:appcompat-v7:25.3.1"
+     implementation "com.android.support:appcompat-v7:${rootProject.ext.supportLibVersion}"
    }
    ```
 3. If necessary, update the `compileSdkVersion` to 25:


### PR DESCRIPTION
misleading appcompat value and option

- [ ] include issue number that will be resolved by this PR (e.g. `Fixes #1234`)
- [x] include a summary of the work
In readme file appcompat was different than the last example project in the repo. It was misleading.
- [x] include steps to verify
Tried to use with the existing value and tested to sign in to google. Worked as expected.
- [ ] update tests (if applicable)
- [x] update readme (if applicable)
- [ ] update typescript definitions (if applicable)
