### PR TITLE
Use pkce android

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ with optional overrides.
   * **authorize** - (`{ [key: string]: value }`) headers to be passed during authorization request.
   * **token** - (`{ [key: string]: value }`) headers to be passed during token retrieval request.
 * **useNonce** - (`boolean`) _IOS_ (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers
-* **usePKCE** - (`boolean`) _IOS_ (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
+* **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 
 #### result
 

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -66,6 +66,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableArray scopes,
             final ReadableMap additionalParameters,
             final ReadableMap serviceConfiguration,
+            final Boolean usePKCE,
             final String clientAuthMethod,
             final Boolean dangerouslyAllowInsecureHttpRequests,
             final ReadableMap headers,
@@ -96,6 +97,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         clientId,
                         scopes,
                         redirectUrl,
+                        usePKCE,
                         additionalParametersMap
                 );
             } catch (Exception e) {
@@ -120,6 +122,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                     clientId,
                                     scopes,
                                     redirectUrl,
+                                    usePKCE,
                                     additionalParametersMap
                             );
                         }
@@ -268,6 +271,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final String clientId,
             final ReadableArray scopes,
             final String redirectUrl,
+            final Boolean usePKCE,
             final Map<String, String> additionalParametersMap
     ) {
 
@@ -309,6 +313,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             }
 
             authRequestBuilder.setAdditionalParameters(additionalParametersMap);
+        }
+
+        if (!usePKCE) {
+            authRequestBuilder.setCodeVerifier(null);
         }
 
         AuthorizationRequest authRequest = authRequestBuilder.build();

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ export const authorize = ({
     scopes,
     additionalParameters,
     serviceConfiguration,
+    usePKCE
   ];
 
   if (Platform.OS === 'android') {
@@ -86,7 +87,6 @@ export const authorize = ({
 
   if (Platform.OS === 'ios') {
     nativeMethodArguments.push(useNonce);
-    nativeMethodArguments.push(usePKCE);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);

--- a/index.js
+++ b/index.js
@@ -76,7 +76,7 @@ export const authorize = ({
     scopes,
     additionalParameters,
     serviceConfiguration,
-    usePKCE
+    usePKCE,
   ];
 
   if (Platform.OS === 'android') {

--- a/index.js
+++ b/index.js
@@ -76,17 +76,18 @@ export const authorize = ({
     scopes,
     additionalParameters,
     serviceConfiguration,
-    usePKCE,
   ];
 
   if (Platform.OS === 'android') {
     nativeMethodArguments.push(clientAuthMethod);
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
+    nativeMethodArguments.push(usePKCE);
   }
 
   if (Platform.OS === 'ios') {
     nativeMethodArguments.push(useNonce);
+    nativeMethodArguments.push(usePKCE);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);

--- a/index.spec.js
+++ b/index.spec.js
@@ -165,10 +165,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
-            config.usePKCE,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.usePKCE
           );
         });
 
@@ -182,10 +182,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
-            config.usePKCE,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.usePKCE
           );
         });
 
@@ -199,10 +199,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
-            config.usePKCE,
             config.clientAuthMethod,
             true,
-            config.customHeaders
+            config.customHeaders,
+            config.usePKCE
           );
         });
       });
@@ -220,10 +220,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
-            config.usePKCE,
             config.clientAuthMethod,
             false,
-            customHeaders
+            customHeaders,
+            config.usePKCE
           );
         });
       });
@@ -374,10 +374,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
-            config.usePKCE,
             config.clientAuthMethod,
             false,
-            customHeaders
+            customHeaders,
+            config.usePKCE
           );
         });
       });
@@ -413,8 +413,8 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
-          true,
-          false
+          false,
+          true
         );
       });
     });
@@ -434,8 +434,8 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
-          true,
-          config.useNonce
+          config.useNonce,
+          true
         );
       });
 
@@ -449,48 +449,8 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
-          false,
-          config.useNonce
-        );
-      });
-    });
-
-    describe('Android-specific usePKCE parameter', () => {
-      beforeEach(() => {
-        require('react-native').Platform.OS = 'android';
-      });
-
-      it('calls the native wrapper with default value `true`', () => {
-        authorize(config, { refreshToken: 'such-token' });
-        expect(mockAuthorize).toHaveBeenCalledWith(
-          config.issuer,
-          config.redirectUrl,
-          config.clientId,
-          config.clientSecret,
-          config.scopes,
-          config.additionalParameters,
-          config.serviceConfiguration,
-          true,
-          config.clientAuthMethod,
-          false,
-          config.customHeaders
-        );
-      });
-
-      it('calls the native wrapper with passed value `false`', () => {
-        authorize({ ...config, usePKCE: false }, { refreshToken: 'such-token' });
-        expect(mockAuthorize).toHaveBeenCalledWith(
-          config.issuer,
-          config.redirectUrl,
-          config.clientId,
-          config.clientSecret,
-          config.scopes,
-          config.additionalParameters,
-          config.serviceConfiguration,
-          false,
-          config.clientAuthMethod,
-          false,
-          config.customHeaders
+          config.useNonce,
+          false
         );
       });
     });

--- a/index.spec.js
+++ b/index.spec.js
@@ -165,6 +165,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
             config.customHeaders
@@ -181,6 +182,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
             config.customHeaders
@@ -197,6 +199,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             true,
             config.customHeaders
@@ -217,6 +220,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
             customHeaders
@@ -370,6 +374,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
             customHeaders
@@ -408,8 +413,8 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
-          false,
-          true
+          true,
+          false
         );
       });
     });
@@ -429,8 +434,8 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
-          config.useNonce,
-          true
+          true,
+          config.useNonce
         );
       });
 
@@ -444,8 +449,48 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
-          config.useNonce,
-          false
+          false,
+          config.useNonce
+        );
+      });
+    });
+
+    describe('Android-specific usePKCE parameter', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'android';
+      });
+
+      it('calls the native wrapper with default value `true`', () => {
+        authorize(config, { refreshToken: 'such-token' });
+        expect(mockAuthorize).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          config.clientSecret,
+          config.scopes,
+          config.additionalParameters,
+          config.serviceConfiguration,
+          true,
+          config.clientAuthMethod,
+          false,
+          config.customHeaders
+        );
+      });
+
+      it('calls the native wrapper with passed value `false`', () => {
+        authorize({ ...config, usePKCE: false }, { refreshToken: 'such-token' });
+        expect(mockAuthorize).toHaveBeenCalledWith(
+          config.issuer,
+          config.redirectUrl,
+          config.clientId,
+          config.clientSecret,
+          config.scopes,
+          config.additionalParameters,
+          config.serviceConfiguration,
+          false,
+          config.clientAuthMethod,
+          false,
+          config.customHeaders
         );
       });
     });


### PR DESCRIPTION
- [x] Implements #279
- [x] Summary of the work: Moved the parameter `usePKCE` to the general config (for Android and iOS), to be able to disable PKCE also on Android.
- [ ] include steps to verify
- [x] update tests (if applicable)
- [x] update readme (if applicable)
- [ ] update typescript definitions (if applicable)
