### PR TITLE
andorid: Change authorize param order

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,10 +79,10 @@ export const authorize = ({
   ];
 
   if (Platform.OS === 'android') {
+    nativeMethodArguments.push(usePKCE);
     nativeMethodArguments.push(clientAuthMethod);
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
-    nativeMethodArguments.push(usePKCE);
   }
 
   if (Platform.OS === 'ios') {

--- a/index.spec.js
+++ b/index.spec.js
@@ -165,10 +165,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
-            config.customHeaders,
-            config.usePKCE
+            config.customHeaders
           );
         });
 
@@ -182,10 +182,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
-            config.customHeaders,
-            config.usePKCE
+            config.customHeaders
           );
         });
 
@@ -199,10 +199,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             true,
-            config.customHeaders,
-            config.usePKCE
+            config.customHeaders
           );
         });
       });
@@ -220,10 +220,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
-            customHeaders,
-            config.usePKCE
+            customHeaders
           );
         });
       });
@@ -374,10 +374,10 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.usePKCE,
             config.clientAuthMethod,
             false,
-            customHeaders,
-            config.usePKCE
+            customHeaders
           );
         });
       });


### PR DESCRIPTION
- [X] include issue number that will be resolved by this PR

Fixes: #285 

- [X] include a summary of the work

This is a bug introduced with the order of the `authorize` function
arguments. `usePKCE` should be moved to the top, in order to be
compliant with the signature of the java function.

- [X] include steps to verify

Run the tests and a sample auth flow on Android to make sure this fix indeed works.

- [X] update tests (if applicable)

- [ ] update readme (if applicable)

- [ ] update typescript definitions (if applicable)
