### PR TITLE
Adds a method to prefetch AuthorizationServiceConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ const result = await authorize(config);
 
 ### `prefetchConfiguration`
 
-This will prefetch the authorization service configuration. Invoking this function is optional
-and will speed up calls to authorize.
+ANDROID This will prefetch the authorization service configuration. Invoking this function is optional
+and will speed up calls to authorize. This is only supported on Android.
 
 ```js
 import { prefetchConfiguration } from 'react-native-app-auth';
 
+const warmAndPrefetchChrome = true
 const config = {
   issuer: '<YOUR_ISSUER_URL>',
   clientId: '<YOUR_CLIENT_ID>',
@@ -94,7 +95,7 @@ const config = {
   scopes: ['<YOUR_SCOPES_ARRAY>'],
 };
 
-prefetchConfiguration(config);
+prefetchConfiguration(warmAndPrefetchChrome, config);
 ```
 
 #### config

--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ const config = {
 const result = await authorize(config);
 ```
 
+### `prefetchConfiguration`
+
+This will prefetch the authorization service configuration. Invoking this function is optional
+and will speed up calls to authorize.
+
+```js
+import { prefetchConfiguration } from 'react-native-app-auth';
+
+const config = {
+  issuer: '<YOUR_ISSUER_URL>',
+  clientId: '<YOUR_CLIENT_ID>',
+  redirectUrl: '<YOUR_REDIRECT_URL>',
+  scopes: ['<YOUR_SCOPES_ARRAY>'],
+};
+
+prefetchConfiguration(config);
+```
+
 #### config
 
 This is your configuration object for the client. The config is passed into each of the methods

--- a/README.md
+++ b/README.md
@@ -87,15 +87,15 @@ and will speed up calls to authorize. This is only supported on Android.
 ```js
 import { prefetchConfiguration } from 'react-native-app-auth';
 
-const warmAndPrefetchChrome = true
 const config = {
+  warmAndPrefetchChrome: true,
   issuer: '<YOUR_ISSUER_URL>',
   clientId: '<YOUR_CLIENT_ID>',
   redirectUrl: '<YOUR_REDIRECT_URL>',
   scopes: ['<YOUR_SCOPES_ARRAY>'],
 };
 
-prefetchConfiguration(warmAndPrefetchChrome, config);
+prefetchConfiguration(config);
 ```
 
 #### config

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,10 +34,6 @@ android {
     lintOptions {
         abortOnError false
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 repositories {

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -73,7 +73,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Promise promise
     ) {
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
-        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
+        final CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
 
         if(!isPrefetched) {
             if (serviceConfiguration != null && mServiceConfiguration.get() == null) {

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -63,7 +63,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     }
 
     @ReactMethod
-    public void prefetchOnce(
+    public void prefetchConfiguration(
         final String issuer,
         final String redirectUrl,
         final String clientId,
@@ -107,7 +107,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         } else {
             fetchConfigurationLatch.countDown();
         }
-        
+
         try {
             fetchConfigurationLatch.await();
             promise.resolve(isPrefetched);
@@ -177,7 +177,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                             }
 
                             mServiceConfiguration.set(fetchedConfiguration);
-                            
+
                             authorizeWithConfiguration(
                                     fetchedConfiguration,
                                     appAuthConfiguration,

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -78,6 +78,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             try {
                 mServiceConfiguration.set(createAuthorizationServiceConfiguration(serviceConfiguration));
                 isPrefetched = true;
+                fetchConfigurationLatch.countDown();
             } catch (Exception e) {
                 promise.reject("RNAppAuth Error", "Failed to convert serviceConfiguration", e);
             }

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -73,7 +73,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Promise promise
     ) {
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
-        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);¨
+        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
 
         if(!isPrefetched) {
             if (serviceConfiguration != null && mServiceConfiguration.get() == null) {

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -72,6 +72,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
     @ReactMethod
     public void prefetchConfiguration(
+        final Boolean warmAndPrefetchChrome,
         final String issuer,
         final String redirectUrl,
         final String clientId,
@@ -81,7 +82,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final ReadableMap headers,
         final Promise promise
     ) {
-        warmChromeCustomTab(reactContext, issuer);
+        if (warmAndPrefetchChrome) {
+            warmChromeCustomTab(reactContext, issuer);
+        }
 
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders);

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.support.annotation.Nullable;
+import android.support.customtabs.CustomTabsIntent;
+import android.os.Build;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -39,6 +41,11 @@ import net.openid.appauth.connectivity.DefaultConnectionBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class RNAppAuthModule extends ReactContextBaseJavaModule implements ActivityEventListener {
 
@@ -50,11 +57,66 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     private Map<String, String> tokenRequestHeaders = null;
     private Map<String, String> additionalParametersMap;
     private String clientSecret;
+    private final AtomicReference<CustomTabsIntent> warmUpIntent = new AtomicReference<>();
+    private ExecutorService warmUpExecutor;
+    private CountDownLatch warmUpIntentLatch = new CountDownLatch(1);
 
     public RNAppAuthModule(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         reactContext.addActivityEventListener(this);
+    }
+
+    @ReactMethod
+    public void warmUpChromeCustomTab(
+        final String redirectUrl,
+        final String clientId,
+        final ReadableArray scopes,
+        final ReadableMap serviceConfiguration,
+        final Boolean dangerouslyAllowInsecureHttpRequests,
+        final Promise promise
+    ) {
+        if (serviceConfiguration != null) {
+            try {
+                final Context context = this.reactContext;
+                final AuthorizationServiceConfiguration convertedServiceConfiguration = createAuthorizationServiceConfiguration(serviceConfiguration);
+                this.warmUpIntentLatch = new CountDownLatch(1);
+                this.warmUpExecutor = Executors.newSingleThreadExecutor();
+
+                String scopesString = null;
+                if (scopes != null) {
+                    scopesString = this.arrayToString(scopes);
+                }
+
+                AuthorizationRequest.Builder warmUpRequestBuilder =
+                        new AuthorizationRequest.Builder(
+                                convertedServiceConfiguration,
+                                clientId,
+                                ResponseTypeValues.CODE,
+                                Uri.parse(redirectUrl)
+                        );
+
+                if (scopesString != null) {
+                    warmUpRequestBuilder.setScope(scopesString);
+                }
+
+                final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
+                final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
+                final AuthorizationService warmUpAuthService = new AuthorizationService(this.reactContext, appAuthConfiguration);
+                final AuthorizationRequest warmUpAuthRequest = warmUpRequestBuilder.build();
+
+                this.warmUpExecutor.execute(() -> {
+                    CustomTabsIntent.Builder intentBuilder = warmUpAuthService.createCustomTabsIntentBuilder(warmUpAuthRequest.toUri());
+                    this.warmUpIntent.set(intentBuilder.build());
+                    this.warmUpIntentLatch.countDown();
+                });
+                promise.resolve(true);
+            } catch(Exception e) {
+                promise.reject("RNAppAuth Warm Up Error", "Failed to warm up Chrome Custom Tab", e);
+            }
+        } else {
+            promise.reject("RNAppAuth Warm Up Error", "Failed to warm up Chrome Custom Tab: ServiceConfiguration missing");
+        }
     }
 
     @ReactMethod

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -104,6 +104,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         builder
                 );
             }
+        } else {
+            fetchConfigurationLatch.countDown();
         }
         
         try {

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -70,9 +70,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final ReadableArray scopes,
         final ReadableMap serviceConfiguration,
         final Boolean dangerouslyAllowInsecureHttpRequests,
+        final ReadableMap headers,
         final Promise promise
     ) {
-        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
+        this.parseHeaderMap(headers);
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders);
         final CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
 
         if(!isPrefetched) {

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -73,35 +73,39 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Promise promise
     ) {
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests);
-        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
-        if (serviceConfiguration != null && mServiceConfiguration.get() == null) {
-            try {
-                mServiceConfiguration.set(createAuthorizationServiceConfiguration(serviceConfiguration));
-                isPrefetched = true;
-                fetchConfigurationLatch.countDown();
-            } catch (Exception e) {
-                promise.reject("RNAppAuth Error", "Failed to convert serviceConfiguration", e);
-            }
-        } else if (mServiceConfiguration.get() == null) {
-            final Uri issuerUri = Uri.parse(issuer);
-            AuthorizationServiceConfiguration.fetchFromUrl(
-                    buildConfigurationUriFromIssuer(issuerUri),
-                    new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
-                        public void onFetchConfigurationCompleted(
-                                @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
-                                @Nullable AuthorizationException ex) {
-                            if (ex != null) {
-                                promise.reject("RNAppAuth Error", "Failed to fetch configuration", ex);
-                                return;
+        CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);¨
+
+        if(!isPrefetched) {
+            if (serviceConfiguration != null && mServiceConfiguration.get() == null) {
+                try {
+                    mServiceConfiguration.set(createAuthorizationServiceConfiguration(serviceConfiguration));
+                    isPrefetched = true;
+                    fetchConfigurationLatch.countDown();
+                } catch (Exception e) {
+                    promise.reject("RNAppAuth Error", "Failed to convert serviceConfiguration", e);
+                }
+            } else if (mServiceConfiguration.get() == null) {
+                final Uri issuerUri = Uri.parse(issuer);
+                AuthorizationServiceConfiguration.fetchFromUrl(
+                        buildConfigurationUriFromIssuer(issuerUri),
+                        new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
+                            public void onFetchConfigurationCompleted(
+                                    @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
+                                    @Nullable AuthorizationException ex) {
+                                if (ex != null) {
+                                    promise.reject("RNAppAuth Error", "Failed to fetch configuration", ex);
+                                    return;
+                                }
+                                mServiceConfiguration.set(fetchedConfiguration);
+                                isPrefetched = true;
+                                fetchConfigurationLatch.countDown();
                             }
-                            mServiceConfiguration.set(fetchedConfiguration);
-                            isPrefetched = true;
-                            fetchConfigurationLatch.countDown();
-                        }
-                    },
-                    builder
-            );
+                        },
+                        builder
+                );
+            }
         }
+        
         try {
             fetchConfigurationLatch.await();
             promise.resolve(isPrefetched);

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ export interface RefreshConfiguration {
   refreshToken: string;
 }
 
-export function warmUpChromeCustomTab(config: AuthConfiguration): Promise<void>;
+export function prefetchOnce(config: AuthConfiguration): Promise<void>;
 
 export function authorize(config: AuthConfiguration): Promise<AuthorizeResult>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,7 @@ export interface RefreshConfiguration {
   refreshToken: string;
 }
 
-export function prefetchOnce(config: AuthConfiguration): Promise<void>;
+export function prefetchConfiguration(config: AuthConfiguration): Promise<void>;
 
 export function authorize(config: AuthConfiguration): Promise<AuthorizeResult>;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,8 @@ export interface RefreshConfiguration {
   refreshToken: string;
 }
 
+export function warmUpChromeCustomTab(config: AuthConfiguration): Promise<void>;
+
 export function authorize(config: AuthConfiguration): Promise<AuthorizeResult>;
 
 export function refresh(

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const validateHeaders = headers => {
   });
 };
 
-export const warmUpChromeCustomTab = ({
+export const prefetchOnce = ({
   issuer,
   redirectUrl,
   clientId,
@@ -62,6 +62,7 @@ export const warmUpChromeCustomTab = ({
     validateRedirectUrl(redirectUrl);
 
     const nativeMethodArguments = [
+      issuer,
       redirectUrl,
       clientId,
       scopes,
@@ -69,7 +70,7 @@ export const warmUpChromeCustomTab = ({
       dangerouslyAllowInsecureHttpRequests,
     ];
 
-    RNAppAuth.warmUpChromeCustomTab(...nativeMethodArguments);
+    RNAppAuth.prefetchOnce(...nativeMethodArguments);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -48,9 +48,8 @@ const validateHeaders = headers => {
   });
 };
 
-export const prefetchConfiguration = async (
-  warmAndPrefetchChrome,
-  {
+export const prefetchConfiguration = async ({
+    warmAndPrefetchChrome,
     issuer,
     redirectUrl,
     clientId,
@@ -58,8 +57,7 @@ export const prefetchConfiguration = async (
     serviceConfiguration,
     dangerouslyAllowInsecureHttpRequests = false,
     customHeaders,
-  }
-) => {
+}) => {
   if (Platform.OS === 'android') {
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ export const prefetchOnce = async ({
       dangerouslyAllowInsecureHttpRequests,
     ];
 
-    await RNAppAuth.prefetchOnce(...nativeMethodArguments);
+    RNAppAuth.prefetchOnce(...nativeMethodArguments);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -49,14 +49,14 @@ const validateHeaders = headers => {
 };
 
 export const prefetchConfiguration = async ({
-    warmAndPrefetchChrome,
-    issuer,
-    redirectUrl,
-    clientId,
-    scopes,
-    serviceConfiguration,
-    dangerouslyAllowInsecureHttpRequests = false,
-    customHeaders,
+  warmAndPrefetchChrome,
+  issuer,
+  redirectUrl,
+  clientId,
+  scopes,
+  serviceConfiguration,
+  dangerouslyAllowInsecureHttpRequests = false,
+  customHeaders,
 }) => {
   if (Platform.OS === 'android') {
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const validateHeaders = headers => {
   });
 };
 
-export const prefetchOnce = async ({
+export const prefetchConfiguration = async ({
   issuer,
   redirectUrl,
   clientId,
@@ -70,7 +70,7 @@ export const prefetchOnce = async ({
       dangerouslyAllowInsecureHttpRequests,
     ];
 
-    RNAppAuth.prefetchOnce(...nativeMethodArguments);
+    RNAppAuth.prefetchConfiguration(...nativeMethodArguments);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ export const prefetchConfiguration = async ({
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);
     validateRedirectUrl(redirectUrl);
-    validateHeaders(customHeaders)
+    validateHeaders(customHeaders);
 
     const nativeMethodArguments = [
       issuer,
@@ -70,7 +70,7 @@ export const prefetchConfiguration = async ({
       scopes,
       serviceConfiguration,
       dangerouslyAllowInsecureHttpRequests,
-      customHeaders
+      customHeaders,
     ];
 
     RNAppAuth.prefetchConfiguration(...nativeMethodArguments);

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ const validateHeaders = headers => {
   });
 };
 
-export const prefetchOnce = ({
+export const prefetchOnce = async ({
   issuer,
   redirectUrl,
   clientId,
@@ -70,7 +70,7 @@ export const prefetchOnce = ({
       dangerouslyAllowInsecureHttpRequests,
     ];
 
-    RNAppAuth.prefetchOnce(...nativeMethodArguments);
+    await RNAppAuth.prefetchOnce(...nativeMethodArguments);
   }
 };
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,31 @@ const validateHeaders = headers => {
   });
 };
 
+export const warmUpChromeCustomTab = ({
+  issuer, 
+  redirectUrl,
+  clientId,
+  scopes,
+  serviceConfiguration,
+  dangerouslyAllowInsecureHttpRequests = false,
+}) => {
+  if (Platform.OS === 'android') {
+    validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
+    validateClientId(clientId);
+    validateRedirectUrl(redirectUrl);
+  
+    const nativeMethodArguments = [
+      redirectUrl,
+      clientId,
+      scopes,
+      serviceConfiguration,
+      dangerouslyAllowInsecureHttpRequests
+    ];
+
+    RNAppAuth.warmUpChromeCustomTab(...nativeMethodArguments);
+  }
+}
+
 export const authorize = ({
   issuer,
   redirectUrl,

--- a/index.js
+++ b/index.js
@@ -66,12 +66,12 @@ export const warmUpChromeCustomTab = ({
       clientId,
       scopes,
       serviceConfiguration,
-      dangerouslyAllowInsecureHttpRequests
+      dangerouslyAllowInsecureHttpRequests,
     ];
 
     RNAppAuth.warmUpChromeCustomTab(...nativeMethodArguments);
   }
-}
+};
 
 export const authorize = ({
   issuer,

--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ const validateHeaders = headers => {
 };
 
 export const warmUpChromeCustomTab = ({
-  issuer, 
+  issuer,
   redirectUrl,
   clientId,
   scopes,
@@ -60,7 +60,7 @@ export const warmUpChromeCustomTab = ({
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);
     validateRedirectUrl(redirectUrl);
-  
+
     const nativeMethodArguments = [
       redirectUrl,
       clientId,

--- a/index.js
+++ b/index.js
@@ -48,15 +48,18 @@ const validateHeaders = headers => {
   });
 };
 
-export const prefetchConfiguration = async ({
-  issuer,
-  redirectUrl,
-  clientId,
-  scopes,
-  serviceConfiguration,
-  dangerouslyAllowInsecureHttpRequests = false,
-  customHeaders,
-}) => {
+export const prefetchConfiguration = async (
+  warmAndPrefetchChrome,
+  {
+    issuer,
+    redirectUrl,
+    clientId,
+    scopes,
+    serviceConfiguration,
+    dangerouslyAllowInsecureHttpRequests = false,
+    customHeaders,
+  }
+) => {
   if (Platform.OS === 'android') {
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);
@@ -64,6 +67,7 @@ export const prefetchConfiguration = async ({
     validateHeaders(customHeaders);
 
     const nativeMethodArguments = [
+      warmAndPrefetchChrome,
       issuer,
       redirectUrl,
       clientId,

--- a/index.js
+++ b/index.js
@@ -55,11 +55,13 @@ export const prefetchConfiguration = async ({
   scopes,
   serviceConfiguration,
   dangerouslyAllowInsecureHttpRequests = false,
+  customHeaders,
 }) => {
   if (Platform.OS === 'android') {
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);
     validateRedirectUrl(redirectUrl);
+    validateHeaders(customHeaders)
 
     const nativeMethodArguments = [
       issuer,
@@ -68,6 +70,7 @@ export const prefetchConfiguration = async ({
       scopes,
       serviceConfiguration,
       dangerouslyAllowInsecureHttpRequests,
+      customHeaders
     ];
 
     RNAppAuth.prefetchConfiguration(...nativeMethodArguments);


### PR DESCRIPTION
This PR is a rebase of https://github.com/FormidableLabs/react-native-app-auth/pull/147.

- I have also addressed the code review comments so this PR should be good to go.
- I have added in warming up and prefetching for Chrome Custom Tabs

Issue Resolved:
- Fixes #145

Summary of the Work:
- Change exposes a method that prefetches the AuthorizationServiceConfiguration and warms the chrome custom tab

