### PR TITLE
Update `react-native` peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "peerDependencies": {
     "invariant": "^2.2.2",
-    "react-native": "^0.50.3"
+    "react-native": ">=0.50.3"
   },
   "devDependencies": {
     "all-contributors-cli": "^4.9.1",


### PR DESCRIPTION
- [x] include issue number that will be resolved by this PR (e.g. `Fixes #1234`)
- [x] include a summary of the work
- [x] include steps to verify
- [ ] update tests (if applicable)
- [ ] update readme (if applicable)
- [ ] update typescript definitions (if applicable)

Fixes: https://github.com/FormidableLabs/react-native-app-auth/issues/300

Updates the required React Native version so that it is greater than or equal to `0.53.0` as discussed in the above issue. This will stop the invalid peer dependency warning you might see on install.

To verify this fix you will need to install the package using Yarn or NPM.