### PR TITLE
Feature/androidx

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+android.enableJetifier=true

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -7,11 +7,10 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.customtabs.CustomTabsCallback;
-import android.support.customtabs.CustomTabsClient;
-import android.support.customtabs.CustomTabsServiceConnection;
-import android.util.Log;
+import androidx.annotation.Nullable;
+import androidx.browser.customtabs.CustomTabsCallback;
+import androidx.browser.customtabs.CustomTabsClient;
+import androidx.browser.customtabs.CustomTabsServiceConnection;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;

--- a/android/src/main/java/com/rnappauth/RNAppAuthPackage.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthPackage.java
@@ -9,6 +9,7 @@ import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.facebook.react.bridge.JavaScriptModule;
+
 public class RNAppAuthPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
+++ b/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
@@ -16,7 +16,7 @@ package com.rnappauth.utils;
 
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import net.openid.appauth.connectivity.ConnectionBuilder;
 

--- a/android/src/main/java/com/rnappauth/utils/MapUtil.java
+++ b/android/src/main/java/com/rnappauth/utils/MapUtil.java
@@ -1,6 +1,6 @@
 package com.rnappauth.utils;
 
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;

--- a/android/src/main/java/com/rnappauth/utils/UnsafeConnectionBuilder.java
+++ b/android/src/main/java/com/rnappauth/utils/UnsafeConnectionBuilder.java
@@ -17,8 +17,8 @@ package com.rnappauth.utils;
 
 import android.annotation.SuppressLint;
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import net.openid.appauth.Preconditions;


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/326

## Description
Upgrade to use [androidx](https://developer.android.com/jetpack/androidx) instead of the old Android support libraries.

## Steps to verify
Install `react-native-app-auth` from this PR, and add the following to the project's `gradle.properties` file:
```
android.useAndroidX=true
android.enableJetifier=true
```
The app should build.
