### PR TITLE
Use implementation instead of compile in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -45,6 +45,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:'+safeExtGet('reactNativeVersion', '+')
-    compile 'net.openid:appauth:0.7.1'
+    implementation 'com.facebook.react:react-native:'+safeExtGet('reactNativeVersion', '+')
+    implementation 'net.openid:appauth:0.7.1'
 }


### PR DESCRIPTION
This will remove the deprecation warning.