### PR TITLE
Update README.md to include support for iOS10 and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,14 @@ Make `AppDelegate` conform to `RNAppAuthAuthorizationFlowManager` with the follo
 + @property(nonatomic, weak)id<RNAppAuthAuthorizationFlowManagerDelegate>authorizationFlowManagerDelegate;
 ```
 
+Add the following code to `AppDelegate.m` (to support iOS 10 and below)
+
+```diff
++ (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *) options {
++  return [self.authorizationFlowManagerDelegate resumeExternalUserAgentFlowWithURL:url];
++ }
+```
+
 #### Integration of the library with a Swift iOS project
 
 The approach mentioned above should also be possible to employ with Swift. In this case one should have to import `RNAppAuth`


### PR DESCRIPTION
## Description

Update instructions to cover iOS10 and below

Fixes #342 ... <!-- Link the issue that will be fixed by merging this PR, e.g. Fixes #1234 -->


## Steps to verify

Following the current instructions for setup callbacks will not work in iOS10 and below. When following the updated instructions, it will. 
