### PR TITLE
Stop onActivityResult from proceeding when intent is null to prevent app from crashing

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -300,6 +300,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         if (requestCode == 0) {
+            if (data == null) {
+                promise.reject("Failed to authenticate", "Data intent is null" );
+                return;
+            }
+            
             final AuthorizationResponse response = AuthorizationResponse.fromIntent(data);
             AuthorizationException exception = AuthorizationException.fromIntent(data);
             if (exception != null) {


### PR DESCRIPTION
Partially fixes https://github.com/FormidableLabs/react-native-app-auth/issues/130 

## Description

There are at least several cases where the app crashes in onActivityResult method when received data intent is null (more about this - https://github.com/FormidableLabs/react-native-app-auth/issues/130). The cause of the crash is that AuthorizationResponse.fromIntent method (imported from net.openid.appauth) has a null checker method, which throws NullPointerException and the user is presented with a native crash info screen. I'm proposing to add a check for data intent being null, and terminate the authorization process if it is (reject the the promise with error message and return from onActivityResult method). As the data intent being null will always end up in crashing the app, there is no point to continue onActivityResult method. Terminating the authorization process instead would be much more user-friendly solution.

## Steps to verify

One of the scenarios to reproduce the crash:

```
1. Open the app
2. Open the idp web login screen in the app
3. Put the app in background
4. Start the app from the device launcher

Prerequisites: android:launchMode="singleTask" in AndroidManifest.xml
```
