### PR TITLE
Add podspec to included `files`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "ios",
     "android",
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "react-native-app-auth.podspec"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/363

## Description

Add the podspec to the bundled files

## Steps to verify

Try to auto-link this library.

You should *not* see
`[!] use_native_modules! skipped the react-native dependency 'react-native-app-auth'. No podspec file was found.` (which is what currently happens with 5.0.0-rc1)
