### PR TITLE
Use the same error message code across platforms

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -268,7 +268,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                 @Nullable AuthorizationException ex) {
                             if (ex != null) {
-                                promise.reject("token_refresh_failed", getErrorMessage(ex));
+                                promise.reject("service_configuration_fetch_error", getErrorMessage(ex));
                                 return;
                             }
 

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -96,7 +96,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                     isPrefetched = true;
                     fetchConfigurationLatch.countDown();
                 } catch (Exception e) {
-                    promise.reject("RNAppAuth Error", "Failed to convert serviceConfiguration", e);
+                    promise.reject("configuration_error", "Failed to convert serviceConfiguration", e);
                 }
             } else if (mServiceConfiguration.get() == null) {
                 final Uri issuerUri = Uri.parse(issuer);
@@ -107,7 +107,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                     @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                     @Nullable AuthorizationException ex) {
                                 if (ex != null) {
-                                    promise.reject("RNAppAuth Error", "Failed to fetch configuration", ex);
+                                    promise.reject("service_configuration_fetch_error", "Failed to fetch configuration", ex);
                                     return;
                                 }
                                 mServiceConfiguration.set(fetchedConfiguration);
@@ -126,7 +126,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             fetchConfigurationLatch.await();
             promise.resolve(isPrefetched);
         } catch (Exception e) {
-            promise.reject("RNAppAuth Error", "Failed to await fetch configuration", e);
+            promise.reject("service_configuration_fetch_error", "Failed to await fetch configuration", e);
         }
     }
 
@@ -175,7 +175,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         additionalParametersMap
                 );
             } catch (Exception e) {
-                promise.reject("Failed to authenticate", e.getMessage());
+                promise.reject("authentication_failed", e.getMessage());
             }
         } else {
             final Uri issuerUri = Uri.parse(issuer);
@@ -186,7 +186,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                 @Nullable AuthorizationException ex) {
                             if (ex != null) {
-                                promise.reject("Failed to fetch configuration", getErrorMessage(ex));
+                                promise.reject("service_configuration_fetch_error", getErrorMessage(ex));
                                 return;
                             }
 
@@ -257,7 +257,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         promise
                 );
             } catch (Exception e) {
-                promise.reject("Failed to refresh token", e.getMessage());
+                promise.reject("token_refresh_failed", e.getMessage());
             }
         } else {
             final Uri issuerUri = Uri.parse(issuer);
@@ -268,7 +268,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                 @Nullable AuthorizationException ex) {
                             if (ex != null) {
-                                promise.reject("Failed to fetch configuration", getErrorMessage(ex));
+                                promise.reject("token_refresh_failed", getErrorMessage(ex));
                                 return;
                             }
 
@@ -300,14 +300,14 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         if (requestCode == 0) {
             if (data == null) {
-                promise.reject("Failed to authenticate", "Data intent is null" );
+                promise.reject("authentication_error", "Data intent is null" );
                 return;
             }
-            
+
             final AuthorizationResponse response = AuthorizationResponse.fromIntent(data);
             AuthorizationException exception = AuthorizationException.fromIntent(data);
             if (exception != null) {
-                promise.reject("Failed to authenticate", getErrorMessage(exception));
+                promise.reject("authentication_error", getErrorMessage(exception));
                 return;
             }
 
@@ -329,7 +329,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         WritableMap map = TokenResponseFactory.tokenResponseToMap(resp, response);
                         authorizePromise.resolve(map);
                     } else {
-                        promise.reject("Failed exchange token", getErrorMessage(ex));
+                        promise.reject("token_exchange_failed", getErrorMessage(ex));
                     }
                 }
             };
@@ -468,7 +468,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                     WritableMap map = TokenResponseFactory.tokenResponseToMap(response);
                     promise.resolve(map);
                 } else {
-                    promise.reject("Failed to refresh token", getErrorMessage(ex));
+                    promise.reject("token_refresh_failed", getErrorMessage(ex));
                 }
             }
         };

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -64,7 +64,7 @@ RCT_REMAP_METHOD(authorize,
         [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
                                                             completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
                                                                 if (!configuration) {
-                                                                    reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                                    reject(@"service_configuration_fetch_error", [error localizedDescription], error);
                                                                     return;
                                                                 }
                                                                 [self authorizeWithConfiguration: configuration
@@ -110,7 +110,7 @@ RCT_REMAP_METHOD(refresh,
         [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
                                                             completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
                                                                 if (!configuration) {
-                                                                    reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                                    reject(@"service_configuration_fetch_error", [error localizedDescription], error);
                                                                     return;
                                                                 }
                                                                 [self refreshWithConfiguration: configuration
@@ -215,7 +215,7 @@ RCT_REMAP_METHOD(refresh,
                                                            resolve([self formatResponse:authState.lastTokenResponse
                                                                withAuthResponse:authState.lastAuthorizationResponse]);
                                                        } else {
-                                                           reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                           reject(@"authentication_failed", [error localizedDescription], error);
                                                        }
                                                    }]; // end [OIDAuthState authStateByPresentingAuthorizationRequest:request
 }
@@ -252,7 +252,7 @@ RCT_REMAP_METHOD(refresh,
                                             if (response) {
                                                 resolve([self formatResponse:response]);
                                             } else {
-                                                reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                reject(@"token_refresh_failed", [error localizedDescription], error);
                                             }
                                         }];
 }


### PR DESCRIPTION
Fixes #377

## Description
The error codes are not the same across platforms, e.g. when the token refresh fails, Android error code is `Failed to refresh token` and iOS is `RNAppAuth Error`. This ensures that the error codes are the same across platforms.

## Error codes
The following error messages can be thrown:
- `service_configuration_fetch_error` - could not fetch the service configuration
- `authentication_failed` - user authentication failed
- `token_refresh_failed` - could not exchange the refresh token for a new JWT