### PR TITLE
Bump AppAuth-iOS dependency to fix iOS 13 compatibility

### DIFF
--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'React'
-  s.dependency 'AppAuth', '1.0.0'
+  s.dependency 'AppAuth', '1.2.0'
 end


### PR DESCRIPTION
Fixes iOS 13 compatibility

openid/AppAuth-iOS#400

## Description

Update AppAuth-iOS dependency to version 1.2.0.
