### PR TITLE
Typescript: Add null as posible token value for RefreshResult

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ export interface RefreshResult {
   accessTokenExpirationDate: string;
   additionalParameters?: { [name: string]: string };
   idToken: string;
-  refreshToken: string;
+  refreshToken: string | null;
   tokenType: string;
 }
 


### PR DESCRIPTION
At least one of the providers (Google) returns no new refresh token upon refresh. Instead, the previous one can be used again.