### PR TITLE
Add dynamic client registration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -24,3 +24,6 @@ rules:
   prettier/prettier:
     - error
     - trailingComma: es5
+  eqeqeq:
+    - error
+    - smart

--- a/.eslintrc
+++ b/.eslintrc
@@ -27,3 +27,5 @@ rules:
   eqeqeq:
     - error
     - smart
+  max-statements:
+    - off

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ with optional overrides.
 * **customHeaders** - (`object`) _ANDROID_ you can specify custom headers to pass during authorize request and/or token request.
   * **authorize** - (`{ [key: string]: value }`) headers to be passed during authorization request.
   * **token** - (`{ [key: string]: value }`) headers to be passed during token retrieval request.
+  * **register** - (`{ [key: string]: value }`) headers to be passed during registration request.
 * **useNonce** - (`boolean`) _IOS_ (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers
 * **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 
@@ -178,6 +179,49 @@ const result = await revoke(config, {
   tokenToRevoke: `<TOKEN_TO_REVOKE>`
 });
 ```
+
+
+### `register`
+
+This will perform [dynamic client registration](https://openid.net/specs/openid-connect-registration-1_0.html) on the given provider.
+If the provider supports dynamic client registration, it will generate a `clientId` for you to use in subsequent calls to this library.
+
+```js
+import { register } from 'react-native-app-auth';
+
+const registerConfig = {
+  issuer: '<YOUR_ISSUER_URL>',
+  redirectUrls: ['<YOUR_REDIRECT_URL>', '<YOUR_OTHER_REDIRECT_URL>'],
+};
+
+const registerResult = await register(registerConfig);
+```
+
+#### registerConfig
+
+* **issuer** - (`string`) same as in authorization config
+* **serviceConfiguration** - (`object`) same as in authorization config
+* **redirectUrls** - (`array<string>`) _REQUIRED_ specifies all of the redirect urls that your client will use for authentication
+* **responseTypes** - (`array<string>`) an array that specifies which [OAuth 2.0 response types](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html) your client will use. The default value is `['code']`
+* **grantTypes** - (`array<string>`) an array that specifies which [OAuth 2.0 grant types](https://oauth.net/2/grant-types/) your client will use. The default value is `['authorization_code']`
+* **subjectType** - (`string`) requests a specific [subject type](https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes) for your client
+* **tokenEndpointAuthMethod** (`string`) specifies which `clientAuthMethod` your client will use for authentication. The default value is `'client_secret_basic'`
+* **additionalParameters** - (`object`) additional parameters that will be passed in the registration request.
+  Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
+  `hello=world&foo=bar` to the authorization request.
+* **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ same as in authorization config
+* **customHeaders** - (`object`) _ANDROID_ same as in authorization config
+
+#### registerResult
+
+This is the result from the auth server
+
+* **clientId** - (`string`) the assigned client id
+* **clientIdIssuedAt** - (`string`) _OPTIONAL_ date string of when the client id was issued
+* **clientSecret** - (`string`) _OPTIONAL_ the assigned client secret
+* **clientSecretExpiresAt** - (`string`) date string of when the client secret expires, which will be provided if `clientSecret` is provided. If `new Date(clientSecretExpiresAt).getTime() === 0`, then the secret never expires
+* **registrationClientUri** - (`string`) _OPTIONAL_ uri that can be used to perform subsequent operations on the registration
+* **registrationAccessToken** - (`string`) token that can be used at the endpoint given by `registrationClientUri` to perform subsequent operations on the registration. Will be provided if `registrationClientUri` is provided
 
 ## Getting started
 

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -171,7 +171,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         promise
                 );
             } catch (Exception e) {
-                promise.reject("Failed to refresh token", e.getMessage());
+                promise.reject("registration_failed", e.getMessage());
             }
         } else {
             final Uri issuerUri = Uri.parse(issuer);
@@ -182,7 +182,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                 @Nullable AuthorizationException ex) {
                             if (ex != null) {
-                                promise.reject("Failed to fetch configuration", getErrorMessage(ex));
+                                promise.reject("service_configuration_fetch_error", getErrorMessage(ex));
                                 return;
                             }
 
@@ -466,7 +466,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                     WritableMap map = RegistrationResponseFactory.registrationResponseToMap(response);
                     promise.resolve(map);
                 } else {
-                    promise.reject("Failed to refresh token", getErrorMessage(ex));
+                    promise.reject("registration_failed", getErrorMessage(ex));
                 }
             }
         };

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -24,6 +24,7 @@ import com.facebook.react.bridge.ReadableType;
 
 import com.rnappauth.utils.MapUtil;
 import com.rnappauth.utils.UnsafeConnectionBuilder;
+import com.rnappauth.utils.RegistrationResponseFactory;
 import com.rnappauth.utils.TokenResponseFactory;
 import com.rnappauth.utils.CustomConnectionBuilder;
 
@@ -36,14 +37,18 @@ import net.openid.appauth.AuthorizationServiceConfiguration;
 import net.openid.appauth.ClientAuthentication;
 import net.openid.appauth.ClientSecretBasic;
 import net.openid.appauth.ClientSecretPost;
+import net.openid.appauth.RegistrationRequest;
+import net.openid.appauth.RegistrationResponse;
 import net.openid.appauth.ResponseTypeValues;
 import net.openid.appauth.TokenResponse;
 import net.openid.appauth.TokenRequest;
 import net.openid.appauth.connectivity.ConnectionBuilder;
 import net.openid.appauth.connectivity.DefaultConnectionBuilder;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.CountDownLatch;
@@ -56,6 +61,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     private Promise promise;
     private Boolean dangerouslyAllowInsecureHttpRequests;
     private String clientAuthMethod = "basic";
+    private Map<String, String> registrationRequestHeaders = null;
     private Map<String, String> authorizationRequestHeaders = null;
     private Map<String, String> tokenRequestHeaders = null;
     private Map<String, String> additionalParametersMap;
@@ -131,6 +137,75 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     }
 
     @ReactMethod
+    public void register(
+        String issuer,
+        final ReadableArray redirectUris,
+        final ReadableArray responseTypes,
+        final ReadableArray grantTypes,
+        final String subjectType,
+        final String tokenEndpointAuthMethod,
+        final ReadableMap additionalParameters,
+        final ReadableMap serviceConfiguration,
+        final Boolean dangerouslyAllowInsecureHttpRequests,
+        final ReadableMap headers,
+        final Promise promise
+    ) {
+        this.parseHeaderMap(headers);
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.registrationRequestHeaders);
+        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
+        final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
+
+        // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
+        if (serviceConfiguration != null || mServiceConfiguration.get() != null) {
+            try {
+                final AuthorizationServiceConfiguration serviceConfig = mServiceConfiguration.get() != null ? mServiceConfiguration.get() : createAuthorizationServiceConfiguration(serviceConfiguration);
+                registerWithConfiguration(
+                        serviceConfig,
+                        appAuthConfiguration,
+                        redirectUris,
+                        responseTypes,
+                        grantTypes,
+                        subjectType,
+                        tokenEndpointAuthMethod,
+                        additionalParametersMap,
+                        promise
+                );
+            } catch (Exception e) {
+                promise.reject("Failed to refresh token", e.getMessage());
+            }
+        } else {
+            final Uri issuerUri = Uri.parse(issuer);
+            AuthorizationServiceConfiguration.fetchFromUrl(
+                    buildConfigurationUriFromIssuer(issuerUri),
+                    new AuthorizationServiceConfiguration.RetrieveConfigurationCallback() {
+                        public void onFetchConfigurationCompleted(
+                                @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
+                                @Nullable AuthorizationException ex) {
+                            if (ex != null) {
+                                promise.reject("Failed to fetch configuration", getErrorMessage(ex));
+                                return;
+                            }
+
+                            mServiceConfiguration.set(fetchedConfiguration);
+
+                            registerWithConfiguration(
+                                    fetchedConfiguration,
+                                    appAuthConfiguration,
+                                    redirectUris,
+                                    responseTypes,
+                                    grantTypes,
+                                    subjectType,
+                                    tokenEndpointAuthMethod,
+                                    additionalParametersMap,
+                                    promise
+                            );
+                        }
+                    },
+                    builder);
+        }
+    }
+
+    @ReactMethod
     public void authorize(
             String issuer,
             final String redirectUrl,
@@ -149,10 +224,6 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders);
         final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
-
-        if (clientSecret != null) {
-            additionalParametersMap.put("client_secret", clientSecret);
-        }
 
         // store args in private fields for later use in onActivityResult handler
         this.promise = promise;
@@ -346,6 +417,64 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     }
 
     /*
+     * Perform dynamic client registration with the provided configuration
+     */
+    private void registerWithConfiguration(
+        final AuthorizationServiceConfiguration serviceConfiguration,
+        final AppAuthConfiguration appAuthConfiguration,
+        final ReadableArray redirectUris,
+        final ReadableArray responseTypes,
+        final ReadableArray grantTypes,
+        final String subjectType,
+        final String tokenEndpointAuthMethod,
+        final Map<String, String> additionalParametersMap,
+        final Promise promise
+    ) {
+        final Context context = this.reactContext;
+
+        AuthorizationService authService = new AuthorizationService(context, appAuthConfiguration);
+
+        RegistrationRequest.Builder registrationRequestBuilder =
+                new RegistrationRequest.Builder(
+                    serviceConfiguration,
+                    arrayToUriList(redirectUris)
+                )
+                    .setAdditionalParameters(additionalParametersMap);
+
+        if (responseTypes != null) {
+            registrationRequestBuilder.setResponseTypeValues(arrayToList(responseTypes));
+        }
+
+        if (grantTypes != null) {
+            registrationRequestBuilder.setGrantTypeValues(arrayToList(grantTypes));
+        }
+
+        if (subjectType != null) {
+            registrationRequestBuilder.setSubjectType(subjectType);
+        }
+
+        if (tokenEndpointAuthMethod != null) {
+            registrationRequestBuilder.setTokenEndpointAuthenticationMethod(tokenEndpointAuthMethod);
+        }
+        
+        RegistrationRequest registrationRequest = registrationRequestBuilder.build();
+
+        AuthorizationService.RegistrationResponseCallback registrationResponseCallback = new AuthorizationService.RegistrationResponseCallback() {
+            @Override
+            public void onRegistrationRequestCompleted(@Nullable RegistrationResponse response, @Nullable AuthorizationException ex) {
+                if (response != null) {
+                    WritableMap map = RegistrationResponseFactory.registrationResponseToMap(response);
+                    promise.resolve(map);
+                } else {
+                    promise.reject("Failed to refresh token", getErrorMessage(ex));
+                }
+            }
+        };
+
+        authService.performRegistrationRequest(registrationRequest, registrationResponseCallback);
+    }
+
+    /*
      * Authorize user with the provided configuration
      */
     private void authorizeWithConfiguration(
@@ -487,6 +616,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         if (headerMap == null) {
             return;
         }
+        if (headerMap.hasKey("register") && headerMap.getType("register") == ReadableType.Map) {
+            this.registrationRequestHeaders = MapUtil.readableMapToHashMap(headerMap.getMap("register"));
+        }
         if (headerMap.hasKey("authorize") && headerMap.getType("authorize") == ReadableType.Map) {
             this.authorizationRequestHeaders = MapUtil.readableMapToHashMap(headerMap.getMap("authorize"));
         }
@@ -525,6 +657,28 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             strBuilder.append(array.getString(i));
         }
         return strBuilder.toString();
+    }
+
+    /*
+     * Create a string list from an array of strings
+     */
+    private List<String> arrayToList(ReadableArray array) {
+        ArrayList<String> list = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            list.add(array.getString(i));
+        }
+        return list;
+    }
+
+    /*
+     * Create a Uri list from an array of strings
+     */
+    private List<Uri> arrayToUriList(ReadableArray array) {
+        ArrayList<Uri> list = new ArrayList<>();
+        for (int i = 0; i < array.size(); i++) {
+            list.add(Uri.parse(array.getString(i)));
+        }
+        return list;
     }
 
     /*

--- a/android/src/main/java/com/rnappauth/utils/MapUtil.java
+++ b/android/src/main/java/com/rnappauth/utils/MapUtil.java
@@ -2,10 +2,14 @@ package com.rnappauth.utils;
 
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.WritableMap;
 
 import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 
 public class MapUtil {
 
@@ -21,5 +25,21 @@ public class MapUtil {
         }
 
         return hashMap;
+    }
+
+    public static final WritableMap createAdditionalParametersMap(Map<String, String> additionalParameters) {
+        WritableMap additionalParametersMap = Arguments.createMap();
+
+        if (!additionalParameters.isEmpty()) {
+
+            Iterator<String> iterator = additionalParameters.keySet().iterator();
+
+            while(iterator.hasNext()) {
+                String key = iterator.next();
+                additionalParametersMap.putString(key, additionalParameters.get(key));
+            }
+        }
+
+        return additionalParametersMap;
     }
 }

--- a/android/src/main/java/com/rnappauth/utils/RegistrationResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/RegistrationResponseFactory.java
@@ -1,0 +1,44 @@
+package com.rnappauth.utils;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+import net.openid.appauth.RegistrationResponse;
+
+public final class RegistrationResponseFactory {
+    /*
+     * Read raw registration response into a React Native map to be passed down the bridge
+     */
+    public static final WritableMap registrationResponseToMap(RegistrationResponse response) {
+        WritableMap map = Arguments.createMap();
+        
+        map.putString("clientId", response.clientId);
+        map.putMap("additionalParameters", MapUtil.createAdditionalParametersMap(response.additionalParameters));
+
+        if (response.clientIdIssuedAt != null) {
+            map.putString("clientIdIssuedAt", DateUtil.formatTimestamp(response.clientIdIssuedAt));
+        }
+
+        if (response.clientSecret != null) {
+            map.putString("clientSecret", response.clientSecret);
+        }
+
+        if (response.clientSecretExpiresAt != null) {
+            map.putString("clientSecretExpiresAt", DateUtil.formatTimestamp(response.clientSecretExpiresAt));
+        }
+
+        if (response.registrationAccessToken != null) {
+            map.putString("registrationAccessToken", response.registrationAccessToken);
+        }
+
+        if (response.registrationClientUri != null) {
+            map.putString("registrationClientUri", response.registrationClientUri.toString());
+        }
+
+        if (response.tokenEndpointAuthMethod != null) {
+            map.putString("tokenEndpointAuthMethod", response.tokenEndpointAuthMethod);
+        }
+
+        return map;
+    }
+}

--- a/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
@@ -9,25 +9,7 @@ import com.facebook.react.bridge.WritableMap;
 import net.openid.appauth.AuthorizationResponse;
 import net.openid.appauth.TokenResponse;
 
-import java.util.Iterator;
-import java.util.Map;
-
 public final class TokenResponseFactory {
-    private static final WritableMap createAdditionalParametersMap(Map<String, String> additionalParameters) {
-        WritableMap additionalParametersMap = Arguments.createMap();
-
-        if (!additionalParameters.isEmpty()) {
-
-            Iterator<String> iterator = additionalParameters.keySet().iterator();
-
-            while(iterator.hasNext()) {
-                String key = iterator.next();
-                additionalParametersMap.putString(key, additionalParameters.get(key));
-            }
-        }
-
-        return additionalParametersMap;
-    }
 
     private static final WritableArray createScopeArray(String scope) {
         WritableArray scopeArray = Arguments.createArray();
@@ -51,7 +33,7 @@ public final class TokenResponseFactory {
         WritableMap map = Arguments.createMap();
 
         map.putString("accessToken", response.accessToken);
-        map.putMap("additionalParameters", createAdditionalParametersMap(response.additionalParameters));
+        map.putMap("additionalParameters", MapUtil.createAdditionalParametersMap(response.additionalParameters));
         map.putString("idToken", response.idToken);
         map.putString("refreshToken", response.refreshToken);
         map.putString("tokenType", response.tokenType);
@@ -70,9 +52,9 @@ public final class TokenResponseFactory {
         WritableMap map = Arguments.createMap();
 
         map.putString("accessToken", response.accessToken);
-        map.putMap("authorizeAdditionalParameters", createAdditionalParametersMap(authResponse.additionalParameters));
-        map.putMap("tokenAdditionalParameters", createAdditionalParametersMap(response.additionalParameters));
-        map.putMap("additionalParameters", createAdditionalParametersMap(response.additionalParameters)); // DEPRECATED
+        map.putMap("authorizeAdditionalParameters", MapUtil.createAdditionalParametersMap(authResponse.additionalParameters));
+        map.putMap("tokenAdditionalParameters", MapUtil.createAdditionalParametersMap(response.additionalParameters));
+        map.putMap("additionalParameters", MapUtil.createAdditionalParametersMap(response.additionalParameters)); // DEPRECATED
         map.putString("idToken", response.idToken);
         map.putString("refreshToken", response.refreshToken);
         map.putString("tokenType", response.tokenType);

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,17 +5,51 @@ export interface ServiceConfiguration {
   registrationEndpoint?: string;
 }
 
-export type BaseAuthConfiguration =
+export type BaseConfiguration =
   | {
-      clientId: string;
       issuer?: string;
       serviceConfiguration: ServiceConfiguration;
     }
   | {
-      clientId: string;
       issuer: string;
       serviceConfiguration?: ServiceConfiguration;
     };
+
+type CustomHeaders = {
+  authorize?: Record<string, string>;
+  token?: Record<string, string>;
+  register?: Record<string, string>;
+};
+
+interface BuiltInRegistrationParameters {
+  client_name?: string;
+  logo_uri?: string;
+  client_uri?: string;
+  policy_uri?: string;
+  tos_uri?: string;
+}
+
+export type RegistrationConfiguration = BaseConfiguration & {
+  redirectUrls: string[];
+  responseTypes?: string[];
+  grantTypes?: string[];
+  subjectType?: string;
+  tokenEndpointAuthMethod?: string;
+  additionalParameters?: BuiltInRegistrationParameters & { [name: string]: string };
+  dangerouslyAllowInsecureHttpRequests?: boolean;
+  customHeaders?: CustomHeaders;
+};
+
+export interface RegistrationResponse {
+  clientId: string;
+  additionalParameters?: { [name: string]: string };
+  clientIdIssuedAt?: string;
+  clientSecret?: string;
+  clientSecretExpiresAt?: string;
+  registrationAccessToken?: string;
+  registrationClientUri?: string;
+  tokenEndpointAuthMethod?: string;
+}
 
 interface BuiltInParameters {
   display?: 'page' | 'popup' | 'touch' | 'wap';
@@ -23,9 +57,8 @@ interface BuiltInParameters {
   prompt?: 'consent' | 'login' | 'none' | 'select_account';
 }
 
-type CustomHeaders = {
-  authorize?: Record<string, string>;
-  token?: Record<string, string>;
+export type BaseAuthConfiguration = BaseConfiguration & {
+  clientId: string;
 };
 
 export type AuthConfiguration = BaseAuthConfiguration & {
@@ -71,6 +104,8 @@ export interface RefreshConfiguration {
 }
 
 export function prefetchConfiguration(config: AuthConfiguration): Promise<void>;
+
+export function register(config: RegistrationConfiguration): Promise<RegistrationResponse>;
 
 export function authorize(config: AuthConfiguration): Promise<AuthorizeResult>;
 

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,8 +1,9 @@
-import { authorize, refresh } from './';
+import { register, authorize, refresh } from './';
 
 jest.mock('react-native', () => ({
   NativeModules: {
     RNAppAuth: {
+      register: jest.fn(),
       authorize: jest.fn(),
       refresh: jest.fn(),
     },
@@ -13,10 +14,14 @@ jest.mock('react-native', () => ({
 }));
 
 describe('AppAuth', () => {
+  let mockRegister;
   let mockAuthorize;
   let mockRefresh;
 
   beforeAll(() => {
+    mockRegister = require('react-native').NativeModules.RNAppAuth.register;
+    mockRegister.mockReturnValue('REGISTERED');
+
     mockAuthorize = require('react-native').NativeModules.RNAppAuth.authorize;
     mockAuthorize.mockReturnValue('AUTHORIZED');
 
@@ -38,8 +43,242 @@ describe('AppAuth', () => {
     customHeaders: null,
   };
 
+  const registerConfig = {
+    issuer: 'test-issuer',
+    redirectUrls: ['test-redirectUrl'],
+    responseTypes: ['code'],
+    grantTypes: ['authorization_code'],
+    subjectType: 'public',
+    tokenEndpointAuthMethod: 'client_secret_post',
+    additionalParameters: {},
+    serviceConfiguration: null,
+  };
+
+  describe('register', () => {
+    beforeEach(() => {
+      mockRegister.mockReset();
+      mockAuthorize.mockReset();
+      mockRefresh.mockReset();
+    });
+
+    it('throws an error when issuer is not a string and serviceConfiguration is not passed', () => {
+      expect(() => {
+        register({ ...registerConfig, issuer: () => ({}) });
+      }).toThrow('Config error: you must provide either an issuer or a registration endpoint');
+    });
+
+    it('throws an error when serviceConfiguration does not have registrationEndpoint and issuer is not passed', () => {
+      expect(() => {
+        register({
+          ...registerConfig,
+          issuer: undefined,
+          serviceConfiguration: { authorizationEndpoint: '' },
+        });
+      }).toThrow('Config error: you must provide either an issuer or a registration endpoint');
+    });
+
+    it('throws an error when redirectUrls is not an Array', () => {
+      expect(() => {
+        register({ ...registerConfig, redirectUrls: 'test-url' });
+      }).toThrow('Config error: redirectUrls must be an Array of strings');
+    });
+
+    it('throws an error when redirectUrls does not contain strings', () => {
+      expect(() => {
+        register({ ...registerConfig, redirectUrls: [null] });
+      }).toThrow('Config error: redirectUrls must be an Array of strings');
+    });
+
+    it('throws an error when responseTypes is not an Array', () => {
+      expect(() => {
+        register({ ...registerConfig, responseTypes: 'test-type' });
+      }).toThrow('Config error: if provided, responseTypes must be an Array of strings');
+    });
+
+    it('throws an error when responseTypes does not contain strings', () => {
+      expect(() => {
+        register({ ...registerConfig, responseTypes: [null] });
+      }).toThrow('Config error: if provided, responseTypes must be an Array of strings');
+    });
+
+    it('throws an error when grantTypes is not an Array', () => {
+      expect(() => {
+        register({ ...registerConfig, grantTypes: 'test-type' });
+      }).toThrow('Config error: if provided, grantTypes must be an Array of strings');
+    });
+
+    it('throws an error when grantTypes does not contain strings', () => {
+      expect(() => {
+        register({ ...registerConfig, grantTypes: [null] });
+      }).toThrow('Config error: if provided, grantTypes must be an Array of strings');
+    });
+
+    it('throws an error when subjectType is not a string', () => {
+      expect(() => {
+        register({ ...registerConfig, subjectType: 7 });
+      }).toThrow('Config error: if provided, subjectType must be a string');
+    });
+
+    it('throws an error when tokenEndpointAuthMethod is not a string', () => {
+      expect(() => {
+        register({ ...registerConfig, tokenEndpointAuthMethod: () => 'test-method' });
+      }).toThrow('Config error: if provided, tokenEndpointAuthMethod must be a string');
+    });
+
+    it('throws an error when customHeaders has too few keys', () => {
+      expect(() => {
+        register({ ...registerConfig, customHeaders: {} });
+      }).toThrow();
+    });
+
+    it('throws an error when customHeaders has too many keys', () => {
+      expect(() => {
+        register({
+          ...registerConfig,
+          customHeaders: {
+            register: { toto: 'titi' },
+            authorize: { toto: 'titi' },
+            unknownKey: { toto: 'titi' },
+          },
+        });
+      }).toThrow();
+    });
+
+    it('throws an error when customHeaders has unknown keys', () => {
+      expect(() => {
+        register({
+          ...registerConfig,
+          customHeaders: {
+            reg: { toto: 'titi' },
+            authorize: { toto: 'titi' },
+          },
+        });
+      }).toThrow();
+      expect(() => {
+        register({
+          ...registerConfig,
+          customHeaders: {
+            reg: { toto: 'titi' },
+          },
+        });
+      }).toThrow();
+    });
+
+    it('throws an error when customHeaders values arent Record<string,string>', () => {
+      expect(() => {
+        register({
+          ...registerConfig,
+          customHeaders: {
+            register: { toto: {} },
+          },
+        });
+      }).toThrow();
+    });
+
+    it('calls the native wrapper with the correct args on iOS', () => {
+      register(registerConfig);
+      expect(mockRegister).toHaveBeenCalledWith(
+        registerConfig.issuer,
+        registerConfig.redirectUrls,
+        registerConfig.responseTypes,
+        registerConfig.grantTypes,
+        registerConfig.subjectType,
+        registerConfig.tokenEndpointAuthMethod,
+        registerConfig.additionalParameters,
+        registerConfig.serviceConfiguration
+      );
+    });
+
+    describe('Android-specific', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'android';
+      });
+
+      afterEach(() => {
+        require('react-native').Platform.OS = 'ios';
+      });
+
+      describe('dangerouslyAllowInsecureHttpRequests parameter', () => {
+        it('calls the native wrapper with default value `false`', () => {
+          register(registerConfig);
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            false,
+            registerConfig.customHeaders
+          );
+        });
+
+        it('calls the native wrapper with passed value `false`', () => {
+          register({ ...registerConfig, dangerouslyAllowInsecureHttpRequests: false });
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            false,
+            registerConfig.customHeaders
+          );
+        });
+
+        it('calls the native wrapper with passed value `true`', () => {
+          register({ ...registerConfig, dangerouslyAllowInsecureHttpRequests: true });
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            true,
+            registerConfig.customHeaders
+          );
+        });
+      });
+
+      describe('customHeaders parameter', () => {
+        it('calls the native wrapper with headers', () => {
+          const customTokenHeaders = { Authorization: 'Basic someBase64Value' };
+          const customAuthorizeHeaders = { Authorization: 'Basic someOtherBase64Value' };
+          const customRegisterHeaders = { Authorization: 'Basic some3rdBase64Value' };
+          const customHeaders = {
+            token: customTokenHeaders,
+            authorize: customAuthorizeHeaders,
+            register: customRegisterHeaders,
+          };
+          register({ ...registerConfig, customHeaders });
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            false,
+            customHeaders
+          );
+        });
+      });
+    });
+  });
+
   describe('authorize', () => {
     beforeEach(() => {
+      mockRegister.mockReset();
       mockAuthorize.mockReset();
       mockRefresh.mockReset();
     });
@@ -210,7 +449,12 @@ describe('AppAuth', () => {
         it('calls the native wrapper with headers', () => {
           const customTokenHeaders = { Authorization: 'Basic someBase64Value' };
           const customAuthorizeHeaders = { Authorization: 'Basic someOtherBase64Value' };
-          const customHeaders = { token: customTokenHeaders, authorize: customAuthorizeHeaders };
+          const customRegisterHeaders = { Authorization: 'Basic some3rdBase64Value' };
+          const customHeaders = {
+            token: customTokenHeaders,
+            authorize: customAuthorizeHeaders,
+            register: customRegisterHeaders,
+          };
           authorize({ ...config, customHeaders });
           expect(mockAuthorize).toHaveBeenCalledWith(
             config.issuer,
@@ -232,6 +476,7 @@ describe('AppAuth', () => {
 
   describe('refresh', () => {
     beforeEach(() => {
+      mockRegister.mockReset();
       mockAuthorize.mockReset();
       mockRefresh.mockReset();
     });

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -33,6 +33,50 @@ static NSUInteger const kStateSizeBytes = 32;
 static NSUInteger const kCodeVerifierBytes = 32;
 
 RCT_EXPORT_MODULE()
+    
+RCT_REMAP_METHOD(register,
+                 issuer: (NSString *) issuer
+                 redirectUrls: (NSArray *) redirectUrls
+                 responseTypes: (NSArray *) responseTypes
+                 grantTypes: (NSArray *) grantTypes
+                 subjectType: (NSString *) subjectType
+                 tokenEndpointAuthMethod: (NSString *) tokenEndpointAuthMethod
+                 additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                 serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
+                 resolve: (RCTPromiseResolveBlock) resolve
+                 reject: (RCTPromiseRejectBlock)  reject)
+{
+    // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
+    if (serviceConfiguration) {
+        OIDServiceConfiguration *configuration = [self createServiceConfiguration:serviceConfiguration];
+        [self registerWithConfiguration: configuration
+                           redirectUrls: redirectUrls
+                          responseTypes: responseTypes
+                             grantTypes: grantTypes
+                            subjectType: subjectType
+                tokenEndpointAuthMethod: tokenEndpointAuthMethod
+                   additionalParameters: additionalParameters
+                                resolve: resolve
+                                 reject: reject];
+    } else {
+        [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
+                                                            completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
+                                                                if (!configuration) {
+                                                                    reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                                    return;
+                                                                }
+                                                                [self registerWithConfiguration: configuration
+                                                                                   redirectUrls: redirectUrls
+                                                                                  responseTypes: responseTypes
+                                                                                     grantTypes: grantTypes
+                                                                                    subjectType: subjectType
+                                                                        tokenEndpointAuthMethod: tokenEndpointAuthMethod
+                                                                           additionalParameters: additionalParameters
+                                                                                        resolve: resolve
+                                                                                         reject: reject];
+                                                            }];
+    }
+} // end RCT_REMAP_METHOD(register,
 
 RCT_REMAP_METHOD(authorize,
                  issuer: (NSString *) issuer
@@ -163,6 +207,45 @@ RCT_REMAP_METHOD(refresh,
   return [OIDTokenUtilities encodeBase64urlNoPadding:sha256Verifier];
 }
 
+    
+/*
+ * Perform dynamic client registration with provided OIDServiceConfiguration
+ */
+- (void)registerWithConfiguration: (OIDServiceConfiguration *) configuration
+                     redirectUrls: (NSArray *) redirectUrlStrings
+                    responseTypes: (NSArray *) responseTypes
+                       grantTypes: (NSArray *) grantTypes
+                      subjectType: (NSString *) subjectType
+          tokenEndpointAuthMethod: (NSString *) tokenEndpointAuthMethod
+             additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                          resolve: (RCTPromiseResolveBlock) resolve
+                           reject: (RCTPromiseRejectBlock)  reject
+{
+    NSMutableArray<NSURL *> *redirectUrls = [NSMutableArray arrayWithCapacity:[redirectUrlStrings count]];
+    for (NSString *urlString in redirectUrlStrings) {
+        [redirectUrls addObject:[NSURL URLWithString:urlString]];
+    }
+    
+    OIDRegistrationRequest *request =
+    [[OIDRegistrationRequest alloc] initWithConfiguration:configuration
+                                             redirectURIs:redirectUrls
+                                            responseTypes:responseTypes
+                                               grantTypes:grantTypes
+                                              subjectType:subjectType
+                                  tokenEndpointAuthMethod:tokenEndpointAuthMethod
+                                     additionalParameters:additionalParameters];
+    
+    [OIDAuthorizationService performRegistrationRequest:request
+                                             completion:^(OIDRegistrationResponse *_Nullable response,
+                                                          NSError *_Nullable error) {
+                                                 if (response) {
+                                                     resolve([self formatRegistrationResponse:response]);
+                                                 } else {
+                                                     reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                 }
+                                            }];
+}
+    
 /*
  * Authorize a user in exchange for a token with provided OIDServiceConfiguration
  */
@@ -295,6 +378,23 @@ RCT_REMAP_METHOD(refresh,
              @"refreshToken": response.refreshToken ? response.refreshToken : @"",
              @"tokenType": response.tokenType ? response.tokenType : @"",
              @"scopes": authResponse.scope ? [authResponse.scope componentsSeparatedByString:@" "] : [NSArray new],
+             };
+}
+    
+- (NSDictionary*)formatRegistrationResponse: (OIDRegistrationResponse*) response {
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    dateFormat.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
+    [dateFormat setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+    [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+    
+    return @{@"clientId": response.clientID,
+             @"additionalParameters": response.additionalParameters,
+             @"clientIdIssuedAt": response.clientIDIssuedAt ? [dateFormat stringFromDate:response.clientIDIssuedAt] : @"",
+             @"clientSecret": response.clientSecret ? response.clientSecret : @"",
+             @"clientSecretExpiresAt": response.clientSecretExpiresAt ? [dateFormat stringFromDate:response.clientSecretExpiresAt] : @"",
+             @"registrationAccessToken": response.registrationAccessToken ? response.registrationAccessToken : @"",
+             @"registrationClientUri": response.registrationClientURI ? response.registrationClientURI : @"",
+             @"tokenEndpointAuthMethod": response.tokenEndpointAuthenticationMethod ? response.tokenEndpointAuthenticationMethod : @"",
              };
 }
 

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -62,7 +62,7 @@ RCT_REMAP_METHOD(register,
         [OIDAuthorizationService discoverServiceConfigurationForIssuer:[NSURL URLWithString:issuer]
                                                             completion:^(OIDServiceConfiguration *_Nullable configuration, NSError *_Nullable error) {
                                                                 if (!configuration) {
-                                                                    reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                                    reject(@"service_configuration_fetch_error", [error localizedDescription], error);
                                                                     return;
                                                                 }
                                                                 [self registerWithConfiguration: configuration
@@ -241,7 +241,7 @@ RCT_REMAP_METHOD(refresh,
                                                  if (response) {
                                                      resolve([self formatRegistrationResponse:response]);
                                                  } else {
-                                                     reject(@"RNAppAuth Error", [error localizedDescription], error);
+                                                     reject(@"registration_failed", [error localizedDescription], error);
                                                  }
                                             }];
 }


### PR DESCRIPTION
I've started using this library with [Solid](https://github.com/solid/node-solid-server) to authenticate against [inrupt.net](https://inrupt.net/) and [solid.community](https://solid.community/), and since Solid is decentralized it requires apps to [dynamically register](https://openid.net/specs/openid-connect-registration-1_0.html) with the provider. Both AppAuth-Android and AppAuth-iOS provide support for client registration, so I added the Javascript and native code required to take advantage of that. I would really like to get this accepted so that others don't have to start from scratch with this too!

## Description

I've added a new library function, `register`, which can be used to obtain a client id and secret for subsequent calls to `authorize` and other library functions.

I've tested the functionality on iOS and Android, and everything is working properly.

I did end up modifying the eslint settings, since it was giving me errors when using `== null` to check if parameters had been passed to `register`, and since it was limiting the number of statements that could be used in an arrow function, which affected the tests.

<!-- Include a summary of the work -->

## Steps to verify

```javascript
import { register } from 'react-native-app-auth';

const res = await register({
  issuer: 'https://inrupt.net',
  redirectUrls: ['com.myapp.id:/oauthredirect']
});
// res is now { clientId: '...', clientSecret: '...', ... }
````
Let me know if there's anything I can do to help get this approved.