### PR TITLE
move invariant to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   "author": "kadi.kraman@formidable.com",
   "license": "MIT",
   "peerDependencies": {
-    "invariant": "^2.2.2",
     "react-native": ">=0.60.0"
   },
   "devDependencies": {
@@ -72,5 +71,7 @@
     "react": "^16.1.1",
     "react-native": "^0.50.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "invariant": "^2.2.2"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -73,5 +73,5 @@
   },
   "dependencies": {
     "invariant": "^2.2.2"
-  },
+  }
 }


### PR DESCRIPTION
## Description

When installing this projects on a fresh project it complains about having no access to invariant, since most projects include this automatically this won't show in bigger ones. Moving this `dependency` to the `dependencies` array makes the installation for this automatic.

## Steps to verify

Make a fresh project like: https://snack.expo.io/HyXajd03S
