### PR TITLE
check promise before calling it in the android onActivityResult function

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -300,14 +300,18 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         if (requestCode == 0) {
             if (data == null) {
-                promise.reject("Failed to authenticate", "Data intent is null" );
+                if (promise != null) {
+                    promise.reject("Failed to authenticate", "Data intent is null" );
+                }
                 return;
             }
-            
+
             final AuthorizationResponse response = AuthorizationResponse.fromIntent(data);
             AuthorizationException exception = AuthorizationException.fromIntent(data);
             if (exception != null) {
-                promise.reject("Failed to authenticate", getErrorMessage(exception));
+                if (promise != null) {
+                    promise.reject("Failed to authenticate", getErrorMessage(exception));
+                }
                 return;
             }
 
@@ -327,9 +331,13 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         TokenResponse resp, AuthorizationException ex) {
                     if (resp != null) {
                         WritableMap map = TokenResponseFactory.tokenResponseToMap(resp, response);
-                        authorizePromise.resolve(map);
+                        if (authorizePromise != null) {
+                            authorizePromise.resolve(map);
+                        }
                     } else {
-                        promise.reject("Failed exchange token", getErrorMessage(ex));
+                        if (promise != null) {
+                            promise.reject("Failed exchange token", getErrorMessage(ex));
+                        }
                     }
                 }
             };


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/426

## Description

`onActivityResult` is called by all intents when returning to the app from some other location. In the case that we are returning to the app (but not for app auth/or when the intent is null) we trigger a new flow that was added here: https://github.com/FormidableLabs/react-native-app-auth/pull/352
This new flow expects the `promise` instance variable to be set. This only happens in some of the other functions in the native module, e.g. the `authorize` function.

This PR ensures that we check if the promise is defined before we call it. Otherwise the app will crash (which is what I was experiencing prior to this PR)

cc @AlgirdasVZ @kadikraman