### PR TITLE
Update iOS instructions for iOS 10 and below

### DIFF
--- a/Example/ios/RNAppAuthExample/AppDelegate.m
+++ b/Example/ios/RNAppAuthExample/AppDelegate.m
@@ -30,6 +30,10 @@
   return YES;
 }
 
+- (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *) options {
+  return [self.authorizationFlowManagerDelegate resumeExternalUserAgentFlowWithURL:url];
+}
+
 - (NSURL *)sourceURLForBridge:(RCTBridge *)bridge
 {
 #if DEBUG

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Make `AppDelegate` conform to `RNAppAuthAuthorizationFlowManager` with the follo
 Add the following code to `AppDelegate.m` (to support iOS 10 and below)
 
 ```diff
-+ (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *) options {
++ - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *) options {
 +  return [self.authorizationFlowManagerDelegate resumeExternalUserAgentFlowWithURL:url];
 + }
 ```


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/424

- Update iOS instructions for iOS 10 and below
- Add the same piece of code to the example app