### PR TITLE
Fix/fix revoke basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ const config = {
 };
 
 const result = await revoke(config, {
-  tokenToRevoke: `<TOKEN_TO_REVOKE>`
+  tokenToRevoke: `<TOKEN_TO_REVOKE>`,
+  includeBasicAuth: true,
+  sendClientId: true
 });
 ```
 

--- a/docs/config-examples/fitbit.md
+++ b/docs/config-examples/fitbit.md
@@ -30,6 +30,7 @@ const refreshedState = await refresh(config, {
 
 // Revoke token
 await revoke(config, {
-  tokenToRevoke: refreshedState.refreshToken
+  tokenToRevoke: refreshedState.refreshToken,
+  includeBasicAuth: true
 });
 ```

--- a/index.js
+++ b/index.js
@@ -256,7 +256,7 @@ export const revoke = async (
     'Content-Type': 'application/x-www-form-urlencoded',
   };
   if (includeBasicAuthorization) {
-    headers.Authorization = `basic ${base64.encode(`${clientId}:${clientSecret}`)}`;
+    headers.Authorization = `Basic ${base64.encode(`${clientId}:${clientSecret}`)}`;
   }
   /**
     Identity Server insists on client_id being passed in the body,

--- a/index.js
+++ b/index.js
@@ -231,7 +231,7 @@ export const refresh = (
 
 export const revoke = async (
   { clientId, issuer, serviceConfiguration, clientSecret },
-  { tokenToRevoke, sendClientId = false, includeBasicAuthorization = false }
+  { tokenToRevoke, sendClientId = false, includeBasicAuth = false }
 ) => {
   invariant(tokenToRevoke, 'Please include the token to revoke');
   validateClientId(clientId);
@@ -255,7 +255,7 @@ export const revoke = async (
   const headers = {
     'Content-Type': 'application/x-www-form-urlencoded',
   };
-  if (includeBasicAuthorization) {
+  if (includeBasicAuth) {
     headers.Authorization = `Basic ${base64.encode(`${clientId}:${clientSecret}`)}`;
   }
   /**


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/423

- `Basic` in the Auth header for basic auth needs to be capitlaized
- rename `includeBasicAuthorization` to `includeBasicAuth` for brevity
- update FitBit example with the correct config
- use the new config param in the example in the Readme
