### PR TITLE
Remove deprecated variable additionalParameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ This is the result from the auth server
 * **accessTokenExpirationDate** - (`string`) the token expiration date
 * **authorizeAdditionalParameters** - (`Object`) additional url parameters from the authorizationEndpoint response.
 * **tokenAdditionalParameters** - (`Object`) additional url parameters from the tokenEndpoint response.
-* **additionalParameters** - (`Object`) :warning: _DEPRECATED_ legacy implementation. Will be removed in a future release. Returns just `tokenAdditionalParameters` for Android and `authorizeAdditionalParameters` on iOS
 * **idToken** - (`string`) the id token
 * **refreshToken** - (`string`) the refresh token
 * **tokenType** - (`string`) the token type, e.g. Bearer

--- a/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
@@ -54,7 +54,6 @@ public final class TokenResponseFactory {
         map.putString("accessToken", response.accessToken);
         map.putMap("authorizeAdditionalParameters", MapUtil.createAdditionalParametersMap(authResponse.additionalParameters));
         map.putMap("tokenAdditionalParameters", MapUtil.createAdditionalParametersMap(response.additionalParameters));
-        map.putMap("additionalParameters", MapUtil.createAdditionalParametersMap(response.additionalParameters)); // DEPRECATED
         map.putString("idToken", response.idToken);
         map.putString("refreshToken", response.refreshToken);
         map.putString("tokenType", response.tokenType);

--- a/index.d.ts
+++ b/index.d.ts
@@ -78,7 +78,6 @@ export interface AuthorizeResult {
   accessTokenExpirationDate: string;
   authorizeAdditionalParameters?: { [name: string]: string };
   tokenAdditionalParameters?: { [name: string]: string };
-  additionalParameters?: { [name: string]: string };
   idToken: string;
   refreshToken: string;
   tokenType: string;

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -383,7 +383,6 @@ RCT_REMAP_METHOD(refresh,
              @"accessTokenExpirationDate": response.accessTokenExpirationDate ? [dateFormat stringFromDate:response.accessTokenExpirationDate] : @"",
              @"authorizeAdditionalParameters": authResponse.additionalParameters,
              @"tokenAdditionalParameters": response.additionalParameters,
-             @"additionalParameters": authResponse.additionalParameters, /* DEPRECATED */
              @"idToken": response.idToken ? response.idToken : @"",
              @"refreshToken": response.refreshToken ? response.refreshToken : @"",
              @"tokenType": response.tokenType ? response.tokenType : @"",


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/341

The variable `additionalParameters` in token response has been replaced with `authorizeAdditionalParameters` and `tokenAdditionalParameters`.

`authorizeAdditionalParameters` - the additional params that were returned from the `/authorize` request
`tokenAdditionalParameters` - the additional params that were returned from the `/token` request
