### PR TITLE
Fix assembleAndroidTest gradle task

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,10 @@ android {
     lintOptions {
         abortOnError false
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }
 
 repositories {


### PR DESCRIPTION
Fixes #455 

## Description

Add compileOptions to fix build failure in `assembleAndroidTest` task. 

## Steps to verify

I tried running `assembleAndroidTest` in my project and it would not work. I found [this](https://stackoverflow.com/a/49525685) answer and after adding the compileOptions I can run `assembleAndroidTest` successfully. 
