### PR TITLE
Support manual authorization code exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ with optional overrides.
   - **register** - (`{ [key: string]: value }`) headers to be passed during registration request.
 - **useNonce** - (`boolean`) _IOS_ (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers
 - **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
+- **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)
 
 #### result
 
@@ -327,6 +328,19 @@ Add the following code to `AppDelegate.m` (to support iOS 10 and below)
 ```diff
 + - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *) options {
 +  return [self.authorizationFlowManagerDelegate resumeExternalUserAgentFlowWithURL:url];
++ }
+```
+
+If you want to support universal links, add the following to `AppDelegate.m` under `continueUserActivity`
+
+```diff
++ if ([userActivity.activityType isEqualToString:NSUserActivityTypeBrowsingWeb]) {
++   if (self.authorizationFlowManagerDelegate) {
++     BOOL resumableAuth = [self.authorizationFlowManagerDelegate resumeExternalUserAgentFlowWithURL:userActivity.webpageURL];
++     if (resumableAuth) {
++       return YES;
++     }
++   }
 + }
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ with optional overrides.
 
 #### result
 
-This is the result from the auth server
+This is the result from the auth server:
 
 - **accessToken** - (`string`) the access token
 - **accessTokenExpirationDate** - (`string`) the token expiration date
@@ -142,6 +142,7 @@ This is the result from the auth server
 - **refreshToken** - (`string`) the refresh token
 - **tokenType** - (`string`) the token type, e.g. Bearer
 - **scopes** - ([`string`]) the scopes the user has agreed to be granted
+- **authorizationCode** - (`string`) the authorization code (only if `skipCodeExchange=true`)
 
 ### `refresh`
 

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -61,6 +61,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     private final ReactApplicationContext reactContext;
     private Promise promise;
     private Boolean dangerouslyAllowInsecureHttpRequests;
+    private Boolean skipCodeExchange;
     private String clientAuthMethod = "basic";
     private Map<String, String> registrationRequestHeaders = null;
     private Map<String, String> authorizationRequestHeaders = null;
@@ -215,6 +216,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableArray scopes,
             final ReadableMap additionalParameters,
             final ReadableMap serviceConfiguration,
+            final Boolean skipCodeExchange,
             final Boolean usePKCE,
             final String clientAuthMethod,
             final Boolean dangerouslyAllowInsecureHttpRequests,
@@ -232,6 +234,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         this.additionalParametersMap = additionalParametersMap;
         this.clientSecret = clientSecret;
         this.clientAuthMethod = clientAuthMethod;
+        this.skipCodeExchange = skipCodeExchange;
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
         if (serviceConfiguration != null || mServiceConfiguration.get() != null) {
@@ -390,6 +393,13 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 }
                 return;
             }
+
+            if (this.skipCodeExchange) {
+                WritableMap map = TokenResponseFactory.authorizationResponseToMap(response);
+                promise.resolve(map);
+                return;
+            }
+
 
             final Promise authorizePromise = this.promise;
             final AppAuthConfiguration configuration = createAppAuthConfiguration(

--- a/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
@@ -66,4 +66,24 @@ public final class TokenResponseFactory {
 
         return map;
     }
+
+
+    /*
+     * Read raw authorization into a React Native map to be passed down the bridge
+     */
+    public static final WritableMap authorizationResponseToMap(AuthorizationResponse authResponse) {
+        WritableMap map = Arguments.createMap();
+        map.putString("authorizationCode", authResponse.authorizationCode);
+        map.putString("accessToken", authResponse.accessToken);
+        map.putMap("additionalParameters", MapUtil.createAdditionalParametersMap(authResponse.additionalParameters));
+        map.putString("idToken", authResponse.idToken);
+        map.putString("tokenType", authResponse.tokenType);
+        map.putArray("scopes", createScopeArray(authResponse.scope));
+
+        if (authResponse.accessTokenExpirationTime != null) {
+            map.putString("accessTokenExpirationTime", DateUtil.formatTimestamp(authResponse.accessTokenExpirationTime));
+        }
+
+        return map;
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   useNonce?: boolean;
   usePKCE?: boolean;
   warmAndPrefetchChrome?: boolean;
+  skipCodeExchange?: boolean;
 };
 
 export interface AuthorizeResult {
@@ -83,6 +84,7 @@ export interface AuthorizeResult {
   refreshToken: string;
   tokenType: string;
   scopes: string[];
+  authorizationCode: string;
 }
 
 export interface RefreshResult {

--- a/index.js
+++ b/index.js
@@ -155,6 +155,7 @@ export const authorize = ({
   clientAuthMethod = 'basic',
   dangerouslyAllowInsecureHttpRequests = false,
   customHeaders,
+  skipCodeExchange = false,
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
@@ -170,6 +171,7 @@ export const authorize = ({
     scopes,
     additionalParameters,
     serviceConfiguration,
+    skipCodeExchange,
   ];
 
   if (Platform.OS === 'android') {

--- a/index.spec.js
+++ b/index.spec.js
@@ -41,6 +41,7 @@ describe('AppAuth', () => {
     useNonce: true,
     usePKCE: true,
     customHeaders: null,
+    skipCodeExchange: false,
   };
 
   const registerConfig = {
@@ -380,8 +381,34 @@ describe('AppAuth', () => {
         config.scopes,
         config.additionalParameters,
         config.serviceConfiguration,
+        config.skipCodeExchange,
         config.useNonce,
         config.usePKCE
+      );
+    });
+
+    it('calls the native wrapper with the default value `false`, `true`, `true`', () => {
+      authorize({
+        issuer: 'test-issuer',
+        redirectUrl: 'test-redirectUrl',
+        clientId: 'test-clientId',
+        clientSecret: 'test-clientSecret',
+        customHeaders: null,
+        additionalParameters: null,
+        serviceConfiguration: null,
+        scopes: ['openid'],
+      });
+      expect(mockAuthorize).toHaveBeenCalledWith(
+        'test-issuer',
+        'test-redirectUrl',
+        'test-clientId',
+        'test-clientSecret',
+        ['openid'],
+        null,
+        null,
+        false,
+        true,
+        true
       );
     });
 
@@ -404,6 +431,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.skipCodeExchange,
             config.usePKCE,
             config.clientAuthMethod,
             false,
@@ -421,6 +449,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            false,
             config.usePKCE,
             config.clientAuthMethod,
             false,
@@ -438,6 +467,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            false,
             config.usePKCE,
             config.clientAuthMethod,
             true,
@@ -464,6 +494,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            false,
             config.usePKCE,
             config.clientAuthMethod,
             false,
@@ -619,6 +650,7 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            false,
             config.usePKCE,
             config.clientAuthMethod,
             false,
@@ -643,6 +675,7 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
+          false,
           true,
           true
         );
@@ -658,6 +691,7 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
+          false,
           false,
           true
         );
@@ -679,6 +713,7 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
+          config.skipCodeExchange,
           config.useNonce,
           true
         );
@@ -694,6 +729,7 @@ describe('AppAuth', () => {
           config.scopes,
           config.additionalParameters,
           config.serviceConfiguration,
+          config.skipCodeExchange,
           config.useNonce,
           false
         );


### PR DESCRIPTION
## Description

Hello neighbours! At [Echo](https://www.echo.co.uk) we have started using this library and decided to fork it to add some 'missing functionality' that we needed. 

In particular, for some OIDC provider, we are explicitly required to keep all secrets safe. We use signed JWTs to prove who we are (during the code exchange) and for security reasons we cannot do this client-side to avoid exposing private keys. Instead, what we do is capture the authorization code and pass it on to an internal service, which will complete the exchange.

We believe this could be useful for more people out there and we'd rather not maintain a separate fork.

The approach we've gone for here is very simple: added a new boolean to `authorize` and change the behaviour based on that. However, we reckon it's a big behaviour change (we're skipping half of the auth flow), so we'd be happy to discuss alternative solutions. Suggestions/comments about this welcome. 

Besides, we've also added a small comment to the README showing how to make sure we capture iOS Universal Links so the view controller is closed as expected. We still need to see if there's anything else to do on the Android side to support app links.
