### PR TITLE
update spotify configuration with token exchange service

### DIFF
--- a/docs/config-examples/spotify.md
+++ b/docs/config-examples/spotify.md
@@ -20,3 +20,27 @@ const config = {
 
 const authState = await authorize(config);
 ```
+
+## Managing Client Secrets
+
+In order to avoid storing the `clientSecret` in the client, Spotify has published a token exchange package that can be used to move this step to the backend: 
+https://github.com/bih/spotify-token-swap-service
+
+The tokenEndpoint should then point to whereever you are hosting this server, and be sure to remove the secret from your app:
+
+```js
+const config = {
+  clientId: '<client_id>', // available on the app page
+  redirectUrl: 'com.myapp:/oauth', // the redirect you defined after creating the app
+  scopes: ['user-read-email', 'playlist-modify-public', 'user-read-private'], // the scopes you need to access
+  serviceConfiguration: {
+    authorizationEndpoint: 'https://accounts.spotify.com/authorize',
+    tokenEndpoint: 'https://my-token-service/api/token',
+  },
+};
+
+const authState = await authorize(config);
+```
+
+
+


### PR DESCRIPTION

## Description
Update Spotify configuration with backend token exchange service

<!-- Include a summary of the work -->

Most articles I read about OAuth (including this repo) state that we should never store secrets on the client, but until now I wasn't clear on what this meant - providing a sample configuration which explains a token exchange service might help clarify for others as well

