### PR TITLE
Expose OAuth error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,11 @@ try {
 
 ## Error messages
 
+Values are in the `code` field of the rejected Error object.
+
+- OAuth Authorization [error codes](https://tools.ietf.org/html/rfc6749#section-4.1.2.1)
+- OAuth Access Token [error codes](https://tools.ietf.org/html/rfc6749#section-5.2)
+- OpendID Connect Registration [error codes](https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError)
 - `service_configuration_fetch_error` - could not fetch the service configuration
 - `authentication_failed` - user authentication failed
 - `token_refresh_failed` - could not exchange the refresh token for a new JWT

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -183,7 +183,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                 @Nullable AuthorizationException ex) {
                             if (ex != null) {
-                                promise.reject("service_configuration_fetch_error", getErrorMessage(ex));
+                                promise.reject("service_configuration_fetch_error", ex.getLocalizedMessage(), ex);
                                 return;
                             }
 
@@ -260,7 +260,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                 @Nullable AuthorizationException ex) {
                             if (ex != null) {
-                                promise.reject("service_configuration_fetch_error", getErrorMessage(ex));
+                                promise.reject("service_configuration_fetch_error", ex.getLocalizedMessage(), ex);
                                 return;
                             }
 
@@ -344,7 +344,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                 @Nullable AuthorizationServiceConfiguration fetchedConfiguration,
                                 @Nullable AuthorizationException ex) {
                             if (ex != null) {
-                                promise.reject("service_configuration_fetch_error", getErrorMessage(ex));
+                                promise.reject("service_configuration_fetch_error", ex.getLocalizedMessage(), ex);
                                 return;
                             }
 
@@ -386,7 +386,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             AuthorizationException exception = AuthorizationException.fromIntent(data);
             if (exception != null) {
                 if (promise != null) {
-                    promise.reject("authentication_error", getErrorMessage(exception));
+                    promise.reject(exception.error != null ? exception.error: "authentication_error", exception.getLocalizedMessage(), exception);
                 }
                 return;
             }
@@ -412,7 +412,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         }
                     } else {
                         if (promise != null) {
-                            promise.reject("token_exchange_failed", getErrorMessage(ex));
+                            promise.reject(ex.error != null ? ex.error: "token_exchange_failed", ex.getLocalizedMessage(), ex);
                         }
                     }
                 }
@@ -479,7 +479,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                     WritableMap map = RegistrationResponseFactory.registrationResponseToMap(response);
                     promise.resolve(map);
                 } else {
-                    promise.reject("registration_failed", getErrorMessage(ex));
+                    promise.reject(ex.error != null ? ex.error: "registration_failed", ex.getLocalizedMessage(), ex);
                 }
             }
         };
@@ -610,7 +610,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                     WritableMap map = TokenResponseFactory.tokenResponseToMap(response);
                     promise.resolve(map);
                 } else {
-                    promise.reject("token_refresh_failed", getErrorMessage(ex));
+                    promise.reject(ex.error != null ? ex.error: "token_refresh_failed", ex.getLocalizedMessage(), ex);
                 }
             }
         };
@@ -647,15 +647,6 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         }
 
         return new ClientSecretBasic(clientSecret);
-    }
-
-    /*
-     * Return error information if it is available
-     */
-    private String getErrorMessage(AuthorizationException ex){
-        if(ex.errorDescription == null && ex.error != null)
-            return ex.error;
-        return ex.errorDescription;
     }
 
     /*

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,3 +119,38 @@ export function revoke(
   config: BaseAuthConfiguration,
   revokeConfig: RevokeConfiguration
 ): Promise<void>;
+
+// https://tools.ietf.org/html/rfc6749#section-4.1.2.1
+type OAuthAuthorizationErrorCode =
+  | 'unauthorized_client'
+  | 'access_denied'
+  | 'unsupported_response_type'
+  | 'invalid_scope'
+  | 'server_error'
+  | 'temporarily_unavailable';
+// https://tools.ietf.org/html/rfc6749#section-5.2
+type OAuthTokenErrorCode =
+  | 'invalid_request'
+  | 'invalid_client'
+  | 'invalid_grant'
+  | 'unauthorized_client'
+  | 'unsupported_grant_type'
+  | 'invalid_scope';
+// https://openid.net/specs/openid-connect-registration-1_0.html#RegistrationError
+type OICRegistrationErrorCode = 'invalid_redirect_uri' | 'invalid_client_metadata';
+type AppAuthErrorCode =
+  | 'service_configuration_fetch_error'
+  | 'authentication_failed'
+  | 'token_refresh_failed'
+  | 'registration_failed'
+  | 'browser_not_found';
+
+type ErrorCode =
+  | OAuthAuthorizationErrorCode
+  | OAuthTokenErrorCode
+  | OICRegistrationErrorCode
+  | AppAuthErrorCode;
+
+export interface AppAuthError extends Error {
+  code: ErrorCode;
+}

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -243,7 +243,8 @@ RCT_REMAP_METHOD(refresh,
                                                  if (response) {
                                                      resolve([self formatRegistrationResponse:response]);
                                                  } else {
-                                                     reject(@"registration_failed", [error localizedDescription], error);
+                                                     reject([self getErrorCode: error defaultCode:@"registration_failed"],
+                                                            [error localizedDescription], error);
                                                  }
                                             }];
 }
@@ -308,7 +309,8 @@ RCT_REMAP_METHOD(refresh,
                                                            resolve([self formatResponse:authState.lastTokenResponse
                                                                withAuthResponse:authState.lastAuthorizationResponse]);
                                                        } else {
-                                                           reject(@"authentication_failed", [error localizedDescription], error);
+                                                           reject([self getErrorCode: error defaultCode:@"authentication_failed"],
+                                                                  [error localizedDescription], error);
                                                        }
                                                    }]; // end [OIDAuthState authStateByPresentingAuthorizationRequest:request
 }
@@ -345,7 +347,8 @@ RCT_REMAP_METHOD(refresh,
                                             if (response) {
                                                 resolve([self formatResponse:response]);
                                             } else {
-                                                reject(@"token_refresh_failed", [error localizedDescription], error);
+                                                reject([self getErrorCode: error defaultCode:@"token_refresh_failed"],
+                                                       [error localizedDescription], error);
                                             }
                                         }];
 }
@@ -405,6 +408,53 @@ RCT_REMAP_METHOD(refresh,
              @"registrationClientUri": response.registrationClientURI ? response.registrationClientURI : @"",
              @"tokenEndpointAuthMethod": response.tokenEndpointAuthenticationMethod ? response.tokenEndpointAuthenticationMethod : @"",
              };
+}
+
+- (NSString*)getErrorCode: (NSError*) error defaultCode: (NSString *) defaultCode {
+    if ([[error domain] isEqualToString:OIDOAuthAuthorizationErrorDomain]) {
+        switch ([error code]) {
+            case OIDErrorCodeOAuthAuthorizationInvalidRequest:
+              return @"invalid_request";
+            case OIDErrorCodeOAuthAuthorizationUnauthorizedClient:
+              return @"unauthorized_client";
+            case OIDErrorCodeOAuthAuthorizationAccessDenied:
+              return @"access_denied";
+            case OIDErrorCodeOAuthAuthorizationUnsupportedResponseType:
+              return @"unsupported_response_type";
+            case OIDErrorCodeOAuthAuthorizationAuthorizationInvalidScope:
+              return @"invalid_scope";
+            case OIDErrorCodeOAuthAuthorizationServerError:
+              return @"server_error";
+            case OIDErrorCodeOAuthAuthorizationTemporarilyUnavailable:
+              return @"temporarily_unavailable";
+        }
+    } else if ([[error domain] isEqualToString:OIDOAuthTokenErrorDomain]) {
+        switch ([error code]) {
+            case OIDErrorCodeOAuthTokenInvalidRequest:
+              return @"invalid_request";
+            case OIDErrorCodeOAuthTokenInvalidClient:
+              return @"invalid_client";
+            case OIDErrorCodeOAuthTokenInvalidGrant:
+              return @"invalid_grant";
+            case OIDErrorCodeOAuthTokenUnauthorizedClient:
+              return @"unauthorized_client";
+            case OIDErrorCodeOAuthTokenUnsupportedGrantType:
+              return @"unsupported_grant_type";
+            case OIDErrorCodeOAuthTokenInvalidScope:
+              return @"invalid_scope";
+        }
+    } else if ([[error domain] isEqualToString:OIDOAuthRegistrationErrorDomain]) {
+        switch ([error code]) {
+            case OIDErrorCodeOAuthRegistrationInvalidRequest:
+              return @"invalid_request";
+            case OIDErrorCodeOAuthRegistrationInvalidRedirectURI:
+              return @"invalid_redirect_uri";
+            case OIDErrorCodeOAuthRegistrationInvalidClientMetadata:
+              return @"invalid_client_metadata";
+        }
+    }
+
+    return defaultCode;
 }
 
 @end


### PR DESCRIPTION
Fixes #474

## Description

Exposes OAuth error codes to the JavaScript client.

## Steps to verify

Add deliberate errors in the OAuth calls, log the error responses and check that the appropriate code is present in the error.