### PR TITLE
Update platform iOS to 10.0 in podspec

### DIFF
--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platform     = :ios, '9.0'
+  s.platform     = :ios, '10.0'
   s.source       = { :git => 'https://github.com/FormidableLabs/react-native-app-auth.git' }
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true


### PR DESCRIPTION
# Description

According to React core and React podspec right now is `10.0` should it better to set the same version, it will resolve warning about a target version mismatch.

[React-Core.podspec](https://github.com/facebook/react-native/blob/master/React-Core.podspec)
[React.podspec](https://github.com/facebook/react-native/blob/master/React.podspec)

## Steps to verify

1. `yarn add react-native-app-auth`
2. `cd ios && pod install`
