### PR TITLE
add azure ad b2c example config

### DIFF
--- a/docs/config-examples/azure-active-directory-b2c.md
+++ b/docs/config-examples/azure-active-directory-b2c.md
@@ -1,0 +1,20 @@
+## Azure Active Directory B2C
+
+Detailed documentation [here](https://docs.microsoft.com/en-us/azure/active-directory-b2c/openid-connect).
+
+```js
+const config = {
+  issuer: 'https://<TENANT_NAME>.b2clogin.com/<TENANT_NAME>.onmicrosoft.com/<USER_FLOW_NAME>/v2.0',
+  clientId: '<APPLICATION_ID>',
+  redirectUrl: 'com.myapp://redirect/url',
+  scopes: ['openid', 'offline_access']
+};
+
+// Log in to get an authentication token
+const authState = await authorize(config);
+
+// Refresh token
+const refreshedState = await refresh(config, {
+  refreshToken: authState.refreshToken,
+});
+```


### PR DESCRIPTION
Fixes # not sure it's a fix, but in response to https://github.com/FormidableLabs/react-native-app-auth/issues/42

## Description
Adds an example config for Azure Active Directory B2C Provider.

## Steps to verify
Let me know and I can provide the application id, tenant name and user flow.
