### PR TITLE
Return scopes as string

### DIFF
--- a/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
@@ -57,7 +57,7 @@ public final class TokenResponseFactory {
         map.putString("idToken", response.idToken);
         map.putString("refreshToken", response.refreshToken);
         map.putString("tokenType", response.tokenType);
-        map.putArray("scopes", createScopeArray(authResponse.scope));
+        map.putString("scopes", authResponse.scope);
 
         if (response.accessTokenExpirationTime != null) {
             map.putString("accessTokenExpirationDate", DateUtil.formatTimestamp(response.accessTokenExpirationTime));

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -386,7 +386,7 @@ RCT_REMAP_METHOD(refresh,
              @"idToken": response.idToken ? response.idToken : @"",
              @"refreshToken": response.refreshToken ? response.refreshToken : @"",
              @"tokenType": response.tokenType ? response.tokenType : @"",
-             @"scopes": authResponse.scope ? [authResponse.scope componentsSeparatedByString:@" "] : [NSArray new],
+             @"scopes": authResponse.scope ? authResponse.scope : @""
              };
 }
     


### PR DESCRIPTION
## Description
In Strava, they return scopes as `read,activity:read`. Current code can not parse it because it used `space` as a separator.
```
String[] scopesArray = scope.split(" ");
```
```
@"scopes": authResponse.scope ? [authResponse.scope componentsSeparatedByString:@" "] : [NSArray new],
```

## Solution
I suggest to return scopes as string instead. So it will works in every cases.

## Breaking changes
Scopes returned as string instead of array

Before
```
{
  "accessToken": "",
  "accessTokenExpirationDate": "",
  "authorizeAdditionalParameters": {},
  "idToken": null,
  "refreshToken": "",
  "scopes": [],
  "tokenAdditionalParameters": {},
  "tokenType": "Bearer"
}
```
After
```
{
  "accessToken": "",
  "accessTokenExpirationDate": "",
  "authorizeAdditionalParameters": {},
  "idToken": null,
  "refreshToken": "",
  "scopes": "read,activity:read",           <-- This line
  "tokenAdditionalParameters": {},
  "tokenType": "Bearer"
}
```

---

will fix https://github.com/FormidableLabs/react-native-app-auth/issues/522