### PR TITLE
[Android] parse additional data

### DIFF
--- a/android/src/main/java/com/rnappauth/utils/MapUtil.java
+++ b/android/src/main/java/com/rnappauth/utils/MapUtil.java
@@ -1,11 +1,20 @@
 package com.rnappauth.utils;
 
+import android.util.Log;
+
 import androidx.annotation.Nullable;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeArray;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -36,10 +45,78 @@ public class MapUtil {
 
             while(iterator.hasNext()) {
                 String key = iterator.next();
+                String value = additionalParameters.get(key);
+                // Try to parse to JSON
+                try {
+                    JSONObject jsonObject = new JSONObject(value);
+                    WritableMap json = convertJsonToMap(jsonObject);
+                    additionalParametersMap.putMap(key, json);
+                    continue;
+                } catch (JSONException ignored) {
+
+                }
                 additionalParametersMap.putString(key, additionalParameters.get(key));
             }
         }
 
         return additionalParametersMap;
+    }
+
+    private static WritableMap convertJsonToMap(JSONObject jsonObject) throws JSONException {
+        WritableMap map = new WritableNativeMap();
+
+        Iterator<String> iterator = jsonObject.keys();
+        while (iterator.hasNext()) {
+            String key = iterator.next();
+            Object value = jsonObject.get(key);
+            if (value instanceof JSONObject) {
+                map.putMap(key, convertJsonToMap((JSONObject) value));
+            } else if (value instanceof JSONArray) {
+                map.putArray(key, convertJsonToArray((JSONArray) value));
+            } else if (value instanceof Boolean) {
+                map.putBoolean(key, (Boolean) value);
+            } else if (value instanceof Integer) {
+                map.putInt(key, (Integer) value);
+            } else if (value instanceof Double) {
+                map.putDouble(key, (Double) value);
+            } else if (value instanceof Float) {
+                map.putDouble(key, ((Float) value).doubleValue());
+            } else if (value instanceof Long) {
+                map.putDouble(key, ((Long) value).doubleValue());
+            } else if (value instanceof String) {
+                map.putString(key, (String) value);
+            } else {
+                map.putString(key, value.toString());
+            }
+        }
+        return map;
+    }
+
+    private static WritableArray convertJsonToArray(JSONArray jsonArray) throws JSONException {
+        WritableArray array = new WritableNativeArray();
+
+        for (int i = 0; i < jsonArray.length(); i++) {
+            Object value = jsonArray.get(i);
+            if (value instanceof JSONObject) {
+                array.pushMap(convertJsonToMap((JSONObject) value));
+            } else if (value instanceof JSONArray) {
+                array.pushArray(convertJsonToArray((JSONArray) value));
+            } else if (value instanceof Boolean) {
+                array.pushBoolean((Boolean) value);
+            } else if (value instanceof Integer) {
+                array.pushInt((Integer) value);
+            } else if (value instanceof Double) {
+                array.pushDouble((Double) value);
+            } else if (value instanceof Float) {
+                array.pushDouble(((Float) value).doubleValue());
+            } else if (value instanceof Long) {
+                array.pushDouble(((Long) value).doubleValue());
+            } else if (value instanceof String) {
+                array.pushString((String) value);
+            } else {
+                array.pushString(value.toString());
+            }
+        }
+        return array;
     }
 }


### PR DESCRIPTION
## Description

Currently, there is inconsistent with data between android and ios.
In android, the result will be `{[key: string]: string}`, ios `{[key: string]: any}`. check out below example

Android
```
{
  ...
  "tokenAdditionalParameters": {
    "athlete": "{\"id\":520981216484,\"username\":\"\",\"resource_state\":2,\"firstname\":\"\",\"lastname\":\"VN\",\"city\":null,\"state\":null,\"country\":null,\"sex\":null,\"premium\":false,\"summit\":false,\"created_at\":\"2020-02-09T06:47:28Z\",\"updated_at\":\"2020-05-04T03:30:51Z\",\"badge_type_id\":0,\"friend\":null,\"follower\":null}",
    "expires_at": "1589111632"
  },
}
```
iOS
```
{
  "tokenAdditionalParameters": {
    "athlete": {
      "badge_type_id": 0,
      "city": null,
      "country": null,
      ...
    },
    "expires_at": 1589104237
  },
}
```
## Solutions
In android, try to convert string to JSONObject then convert it to WritableMap

## Breaking changes [android only]
The result will be {[key: string]: any}
