### PR TITLE
Fix crash on android when warming up custom tabs

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -12,6 +12,7 @@ import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabsCallback;
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsServiceConnection;
+import androidx.browser.customtabs.CustomTabsSession;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -762,7 +763,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             @Override
             public void onCustomTabsServiceConnected(ComponentName name, CustomTabsClient client) {
                 client.warmup(0);
-                client.newSession(new CustomTabsCallback()).mayLaunchUrl(Uri.parse(issuer), null, Collections.<Bundle>emptyList());
+                CustomTabsSession session = client.newSession(new CustomTabsCallback());
+                if (session == null) {
+                    return;
+                }
+                session.mayLaunchUrl(Uri.parse(issuer), null, Collections.<Bundle>emptyList());
             }
 
             @Override


### PR DESCRIPTION
Fixes #517

## Description

Handles possibly `null` values returned by [`CustomTabsSession.newSession`](https://developer.android.com/reference/androidx/browser/customtabs/CustomTabsClient#newSession(androidx.browser.customtabs.CustomTabsCallback,%2520int)).

## Steps to verify

1. Have an Android Samsung device
2. Prefetch configuration with `warmAndPrefetchChrome` enabled
3. Should not crash the app
