### PR TITLE
Add trailing slash to redirectUrl in example Azure AD configuration

### DIFF
--- a/docs/config-examples/azure-active-directory-b2c.md
+++ b/docs/config-examples/azure-active-directory-b2c.md
@@ -6,7 +6,7 @@ Detailed documentation [here](https://docs.microsoft.com/en-us/azure/active-dire
 const config = {
   issuer: 'https://<TENANT_NAME>.b2clogin.com/<TENANT_NAME>.onmicrosoft.com/<USER_FLOW_NAME>/v2.0',
   clientId: '<APPLICATION_ID>',
-  redirectUrl: 'com.myapp://redirect/url',
+  redirectUrl: 'com.myapp://redirect/url/',
   scopes: ['openid', 'offline_access']
 };
 

--- a/docs/config-examples/azure-active-directory.md
+++ b/docs/config-examples/azure-active-directory.md
@@ -19,7 +19,7 @@ Please Note:
 const config = {
   issuer: 'https://login.microsoftonline.com/your-tenant-id',
   clientId: 'your-client-id',
-  redirectUrl: 'com.myapp://oauth/redirect',
+  redirectUrl: 'com.myapp://oauth/redirect/',
   additionalParameters: {
     resource: 'your-resource'
   }
@@ -42,7 +42,7 @@ The V2 endpoint follows the standard OAuth protocol with scopes. Detailed docume
 const config = {
   issuer: 'https://login.microsoftonline.com/your-tenant-id/v2.0',
   clientId: 'your-client-id',
-  redirectUrl: 'com.myapp://oauth/redirect',
+  redirectUrl: 'com.myapp://oauth/redirect/',
   scopes: ['openid', 'profile', 'email', 'offline_access']
 };
 


### PR DESCRIPTION
Helps with #380

## Description

Azure AD provides the redirectUrl without a trailing slash (e.g. msauth.org.reactjs.native.example.MyApp://auth for ios), however `authorize` doesn't return a response unless this value has a trailing slash, as described in #380 .

In this PR I just added a / to the redirectUrl in the example config for AzureAD in order to make it slightly clearer that it is required. 

I didn't add a note explaining this as I'm not certain that this is also the case for AzureAD V1 in addition to V2 but happy to take advice on this. 

## Steps to verify

N/A - documentation only