### PR TITLE
[Android] Authenticate using third party app

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ with optional overrides.
 - **additionalParameters** - (`object`) additional parameters that will be passed in the authorization request.
   Must be string values! E.g. setting `additionalParameters: { hello: 'world', foo: 'bar' }` would add
   `hello=world&foo=bar` to the authorization request.
+  - `use_app`: [Android only] specific the application package name that you'd like to use for authenticating. Otherwise, use webview as default.
 - **clientAuthMethod** - (`string`) _ANDROID_ Client Authentication Method. Can be either `basic` (default) for [Basic Authentication](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/ClientSecretBasic.java) or `post` for [HTTP POST body Authentication](https://github.com/openid/AppAuth-Android/blob/master/library/java/net/openid/appauth/ClientSecretPost.java)
 - **dangerouslyAllowInsecureHttpRequests** - (`boolean`) _ANDROID_ whether to allow requests over plain HTTP or with self-signed SSL certificates. :warning: Can be useful for testing against local server, _should not be used in production._ This setting has no effect on iOS; to enable insecure HTTP requests, add a [NSExceptionAllowsInsecureHTTPLoads exception](https://cocoacasts.com/how-to-add-app-transport-security-exception-domains) to your App Transport Security settings.
 - **customHeaders** - (`object`) _ANDROID_ you can specify custom headers to pass during authorize request and/or token request.

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,12 @@ interface BuiltInParameters {
   display?: 'page' | 'popup' | 'touch' | 'wap';
   login_prompt?: string;
   prompt?: 'consent' | 'login' | 'none' | 'select_account';
+  /** [Android only] Default use web view for authentication. 
+   * If you'd like to use third party app. Pass its package name here.
+   * 
+   * ex. use_app: "com.strava"
+   */
+  use_app?: string;
 }
 
 export type BaseAuthConfiguration = BaseConfiguration & {

--- a/index.js
+++ b/index.js
@@ -55,6 +55,12 @@ const validateHeaders = headers => {
   });
 };
 
+const validateAdditionalParameters = params => {
+  if (Platform.OS !== 'android') {
+    delete params["use_app"];
+  }
+}
+
 export const prefetchConfiguration = async ({
   warmAndPrefetchChrome,
   issuer,
@@ -160,7 +166,7 @@ export const authorize = ({
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
   validateHeaders(customHeaders);
-  // TODO: validateAdditionalParameters
+  validateAdditionalParameters(additionalParameters)
 
   const nativeMethodArguments = [
     issuer,


### PR DESCRIPTION
## Issue
Always use webview for authenticating

## Expected
If `Strava` app installed. Open the app instead of webview

## Description
Add option to pass the third party package name. First, check if this app is installed, open app. Otherwise, use webview as before

## Steps to verify

<!-- Describe steps to verify -->
1. Install Strava app
2. Add option `use_app` to the `additionalParameters `
```
const config: AuthConfiguration = {
        serviceConfiguration: {
          authorizationEndpoint: ''
          tokenEndpoint: '',
          revocationEndpoint: 'https://www.strava.com/oauth/deauthorize',
        },
        redirectUrl,
        scopes: ['activity:read,activity:read_all'],
        additionalParameters: {
          appOAuthUrlScheme: 'strava://oauth/mobile/authorize',
          use_app: 'com.strava',
        },
      };
```
3. Start authenticating with Strava inside our app.
4. Strava app launched for authenticating.
