### PR TITLE
Add a fallback for presenting view controller on ios

### DIFF
--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -301,9 +301,11 @@ RCT_REMAP_METHOD(refresh,
         taskId = UIBackgroundTaskInvalid;
     }];
 
+    UIViewController *presentingViewController = appDelegate.window.rootViewController.view.window ? appDelegate.window.rootViewController : appDelegate.window.rootViewController.presentedViewController;
+
     if (skipCodeExchange) {
         _currentSession = [OIDAuthorizationService presentAuthorizationRequest:request
-                                   presentingViewController:appDelegate.window.rootViewController
+                                   presentingViewController:presentingViewController
                                                     callback:^(OIDAuthorizationResponse *_Nullable authorizationResponse, NSError *_Nullable error) {
                                                        typeof(self) strongSelf = weakSelf;
                                                        strongSelf->_currentSession = nil;
@@ -318,7 +320,7 @@ RCT_REMAP_METHOD(refresh,
                                                    }]; // end [OIDAuthState presentAuthorizationRequest:request
     } else {
         _currentSession = [OIDAuthState authStateByPresentingAuthorizationRequest:request
-                                presentingViewController:appDelegate.window.rootViewController
+                                presentingViewController:presentingViewController
                                                 callback:^(OIDAuthState *_Nullable authState,
                                                             NSError *_Nullable error) {
                                                     typeof(self) strongSelf = weakSelf;


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/534

Adding a fallback for when the view controller is presented modally over the root view controller (e.g. when using react-native-navigation).