### PR TITLE
Upgrade AppAuth-iOS to v1.4.0

### DIFF
--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'React'
-  s.dependency 'AppAuth', '1.2.0'
+  s.dependency 'AppAuth', '1.4.0'
 end


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/547

## Description

Looks like Apple can reject the build based on a comment about UIWebView 🤨 - this has been resolved in the latest AppAuth-iOS version.