### PR TITLE
Fix podspec to the correct version tag

### DIFF
--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.authors      = package['author']
   s.homepage     = package['homepage']
   s.platform     = :ios, '10.0'
-  s.source       = { :git => 'https://github.com/FormidableLabs/react-native-app-auth.git' }
+  s.source       = { :git => 'https://github.com/FormidableLabs/react-native-app-auth.git', :tag => "v#{s.version}" }
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'React'


### PR DESCRIPTION
Fixes https://github.com/FormidableLabs/react-native-app-auth/issues/552

## Description

The source in Podspec was pointing to the latest `main` instead of the correct version tag of the code. This does not cause problems when autolinking, but when linking the library manually, it'll install the latest version of the library from the `main` branch instead of the tag that was released. This ensures we fetch the correct tagged version.

## Steps to verify

1. Create a new project (or remove the react-native-app-auth dependency from the Example app and re-install it with `yarn add `react-native-app-auth`)
2. Add the following to the Podspec
```
pod 'react-native-app-auth', :podspec => '../node_modules/react-native-app-auth/react-native-app-auth.podspec'
```
3. Run `pod install`
4. Run the app and verify that the error occurs
5. Apply the change in this PR and run `pod install` again
6. Verify the error no longer occurs since the correct tagged version was installed