### PR TITLE
Add FusionAuth configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ These providers are OpenID compliant, which means you can use [autodiscovery](ht
 
 - [Identity Server4](https://demo.identityserver.io/) ([Example configuration](./docs/config-examples/identity-server-4.md))
 - [Identity Server3](https://github.com/IdentityServer/IdentityServer3.md) ([Example configuration](./docs/config-examples/identity-server-3.md))
+- [FusionAuth](https://fusionauth.io) ([Example configuration](./docs/config-examples/fusionauth.md))
 - [Google](https://developers.google.com/identity/protocols/OAuth2)
   ([Example configuration](./docs/config-examples/google.md))
 - [Okta](https://developer.okta.com) ([Example configuration](./docs/config-examples/okta.md))

--- a/docs/config-examples/fusionauth.md
+++ b/docs/config-examples/fusionauth.md
@@ -25,4 +25,4 @@ const refreshedState = await refresh(config, {
 });
 ```
 
-
+Check out a full tutorial here: https://fusionauth.io/blog/2020/08/19/securing-react-native-with-oauth

--- a/docs/config-examples/fusionauth.md
+++ b/docs/config-examples/fusionauth.md
@@ -1,0 +1,28 @@
+# FusionAuth
+
+FusionAuth does not specify a revocation endpoint so revoke functionality doesn't work. Other than that, full functionality is available.
+
+* [Install FusionAuth](https://fusionauth.io/docs/v1/tech/installation-guide).
+* Create an application in the admin screen. Note the client id.
+* Set the redirect_uri for the application to be a value like `fusionauth.demo:/oauthredirect` where `fusionauth.demo` is a scheme you've registered in your application.
+
+Use the following configuration (replacing the `clientId` with your application id and `fusionAuth.demo` with your scheme):
+
+```js
+const config = {
+  issuer: 'http://localhost:9011',
+  clientId: '253eb7aa-687a-4bf3-b12b-26baa40eecbf',
+  redirectUrl: 'fusionauth.demo:/callback'
+  scopes: ['offline_access', 'openid']
+};
+
+// Log in to get an authentication token
+const authState = await authorize(config);
+
+// Refresh token
+const refreshedState = await refresh(config, {
+  refreshToken: authState.refreshToken,
+});
+```
+
+


### PR DESCRIPTION
This adds a sample configuration for FusionAuth.

Since this was tested here: https://fusionauth.io/blog/2020/08/19/securing-react-native-with-oauth I added it to the readme. If the readme's 'tested' section is reserved for servers tested by FormidableLabs, I can either:

* make a FusionAuth server available to you (or you can use the Docker image available on the website) 
or
* remove that line

It wasn't clear to me if my addition was appropriate, so please let me know.

Full disclosure, I work for FusionAuth.