### PR TITLE
Fix React dependency to enable XCode 12 build

### DIFF
--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -13,6 +13,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/FormidableLabs/react-native-app-auth.git', :tag => "v#{s.version}" }
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'AppAuth', '1.4.0'
 end


### PR DESCRIPTION
Fixes https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Description

Check linked Issue, it describes the faulty dependency.
<!-- Include a summary of the work -->

## Steps to verify

<!-- Describe steps to verify -->

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
