### PR TITLE
Added a missing comma in the fusionAuth config

### DIFF
--- a/docs/config-examples/fusionauth.md
+++ b/docs/config-examples/fusionauth.md
@@ -12,8 +12,8 @@ Use the following configuration (replacing the `clientId` with your application 
 const config = {
   issuer: 'http://localhost:9011',
   clientId: '253eb7aa-687a-4bf3-b12b-26baa40eecbf',
-  redirectUrl: 'fusionauth.demo:/callback'
-  scopes: ['offline_access', 'openid']
+  redirectUrl: 'fusionauth.demo:/callback',
+  scopes: ['offline_access', 'openid'],
 };
 
 // Log in to get an authentication token


### PR DESCRIPTION
Fixes #573  <!-- Link the issue that will be fixed by merging this PR, e.g. Fixes #1234 -->

## Description

Missing comma has been added to the FA example

## Steps to verify

C'mon... its just an example in the documentation so that nobody is gonna go crazy over a missing comma :P
