### PR TITLE
Add custom state as an additional parameter in Android.

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -547,6 +547,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 authRequestBuilder.setPrompt(additionalParametersMap.get("prompt"));
                 additionalParametersMap.remove("prompt");
             }
+            if (additionalParametersMap.containsKey("state")) {
+                authRequestBuilder.setState(additionalParametersMap.get("state"));
+                additionalParametersMap.remove("state");
+            }
 
             authRequestBuilder.setAdditionalParameters(additionalParametersMap);
         }


### PR DESCRIPTION
Fixes #504, adds the ability to add a custom `state` as an additional parameter in Android.

## Description

Implemented `authRequestBuilder.setState` alongside the other special additional parameters.  Per the [AuthorizationRequest.Builder documentation](https://openid.github.io/AppAuth-Android/docs/latest/net/openid/appauth/AuthorizationRequest.Builder.html#setState-java.lang.String-), not explicitly setting the state via this method already adds a random state value.  So this change simply gives the developer a way to control the value.

## Steps to verify

Add a `state` value to the additional parameters object in the configuration in Android.  An error is no longer thrown.
