### PR TITLE
Added clarification to the azure example config.

### DIFF
--- a/docs/config-examples/azure-active-directory.md
+++ b/docs/config-examples/azure-active-directory.md
@@ -54,3 +54,5 @@ const refreshedState = await refresh(config, {
   refreshToken: authState.refreshToken,
 });
 ```
+
+**Important** When you add your app in the azure portal and are given a `redirectUrl` to use, make sure you add a trailing slash when you add it to your config - e.g. `msauth.BUNDLEID://auth/` - failure to add that causes it to fail in IOS.


### PR DESCRIPTION
## Description

I've added a clarification note to the example azure config. There is a very annoying issue on IOS where if you don't add a trailing slash to the azure `redirtUrl` it won't work - the authorize call will never return.

Hat-top to @isnifer for pointing this out here: https://github.com/FormidableLabs/react-native-app-auth/issues/380#issuecomment-581517451
