### PR TITLE
fix: guard null promise in case of skipCodeExchange

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -397,7 +397,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
             if (this.skipCodeExchange) {
                 WritableMap map = TokenResponseFactory.authorizationResponseToMap(response);
-                promise.resolve(map);
+                if (promise != null) {
+                    promise.resolve(map);
+                }
                 return;
             }
 


### PR DESCRIPTION
Fixes #594 

## Description

Add a guard before using promise in case it's null when `skipCodeExchange` is `true`
