### PR TITLE
Avoid crash on Android when no browsers are found

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -270,15 +270,21 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
                             setServiceConfiguration(issuer, fetchedConfiguration);
 
-                            authorizeWithConfiguration(
-                                    fetchedConfiguration,
-                                    appAuthConfiguration,
-                                    clientId,
-                                    scopes,
-                                    redirectUrl,
-                                    usePKCE,
-                                    additionalParametersMap
-                            );
+                            try {
+                                authorizeWithConfiguration(
+                                        fetchedConfiguration,
+                                        appAuthConfiguration,
+                                        clientId,
+                                        scopes,
+                                        redirectUrl,
+                                        usePKCE,
+                                        additionalParametersMap
+                                );
+                            } catch (ActivityNotFoundException e) {
+                                promise.reject("browser_not_found", e.getMessage());
+                            } catch (Exception e) {
+                                promise.reject("authentication_failed", e.getMessage());
+                            }
                         }
                     },
                     builder
@@ -354,18 +360,24 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
                             setServiceConfiguration(issuer, fetchedConfiguration);
 
-                            refreshWithConfiguration(
-                                    fetchedConfiguration,
-                                    appAuthConfiguration,
-                                    refreshToken,
-                                    clientId,
-                                    scopes,
-                                    redirectUrl,
-                                    additionalParametersMap,
-                                    clientAuthMethod,
-                                    clientSecret,
-                                    promise
-                            );
+                            try {
+                                refreshWithConfiguration(
+                                        fetchedConfiguration,
+                                        appAuthConfiguration,
+                                        refreshToken,
+                                        clientId,
+                                        scopes,
+                                        redirectUrl,
+                                        additionalParametersMap,
+                                        clientAuthMethod,
+                                        clientSecret,
+                                        promise
+                                );
+                            } catch (ActivityNotFoundException e) {
+                                promise.reject("browser_not_found", e.getMessage());
+                            } catch (Exception e) {
+                                promise.reject("token_refresh_failed", e.getMessage());
+                            }
                         }
                     },
                     builder);


### PR DESCRIPTION
Additional fix for #385

This is meant as a bugfix on v5 as well as v6.

## Description

A try-catch has been added around the call to _authorizeWithConfiguration_ inside _onFetchConfigurationCompleted_.

Previous fix (#385) handled the situation where the service configuration was passed in manually, while this new fix also handles the case where the configuration is retrieved from the OpenID well-known discovery endpoint.

## Steps to verify

Remove all browsers on Android device. 

Call _authorize_ without setting the _serviceConfiguration_, so that the service configuration will be retrieved from the well-known endpoint.

A browser_not_found error is returned in the promise, instead of throwing an exception which crashes app.

