### PR TITLE
Return codeVerifier value when both skipCodeExchange=true and usePKCE=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ This is the result from the auth server:
 - **tokenType** - (`string`) the token type, e.g. Bearer
 - **scopes** - ([`string`]) the scopes the user has agreed to be granted
 - **authorizationCode** - (`string`) the authorization code (only if `skipCodeExchange=true`)
+- **codeVerifier** - (`string`) the codeVerifier value used for the PKCE exchange (only if both `skipCodeExchange=true` and `usePKCE=true`)
 
 ### `refresh`
 

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -39,6 +39,7 @@ import net.openid.appauth.AuthorizationServiceConfiguration;
 import net.openid.appauth.ClientAuthentication;
 import net.openid.appauth.ClientSecretBasic;
 import net.openid.appauth.ClientSecretPost;
+import net.openid.appauth.CodeVerifierUtil;
 import net.openid.appauth.RegistrationRequest;
 import net.openid.appauth.RegistrationResponse;
 import net.openid.appauth.ResponseTypeValues;
@@ -63,6 +64,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     private Promise promise;
     private boolean dangerouslyAllowInsecureHttpRequests;
     private Boolean skipCodeExchange;
+    private Boolean usePKCE;
+    private String codeVerifier;
     private String clientAuthMethod = "basic";
     private Map<String, String> registrationRequestHeaders = null;
     private Map<String, String> authorizationRequestHeaders = null;
@@ -236,6 +239,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         this.clientSecret = clientSecret;
         this.clientAuthMethod = clientAuthMethod;
         this.skipCodeExchange = skipCodeExchange;
+        this.usePKCE = usePKCE;
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
         if (serviceConfiguration != null || hasServiceConfiguration(issuer)) {
@@ -396,7 +400,13 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             }
 
             if (this.skipCodeExchange) {
-                WritableMap map = TokenResponseFactory.authorizationResponseToMap(response);
+                WritableMap map;
+                if (this.usePKCE && this.codeVerifier != null) {
+                    map = TokenResponseFactory.authorizationCodeResponseToMap(response, this.codeVerifier);
+                } else {
+                    map = TokenResponseFactory.authorizationResponseToMap(response);
+                }
+
                 if (promise != null) {
                     promise.resolve(map);
                 }
@@ -559,6 +569,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
         if (!usePKCE) {
             authRequestBuilder.setCodeVerifier(null);
+        } else {
+            this.codeVerifier = CodeVerifierUtil.generateRandomCodeVerifier();
+            authRequestBuilder.setCodeVerifier(this.codeVerifier);
         }
 
         AuthorizationRequest authRequest = authRequestBuilder.build();

--- a/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/TokenResponseFactory.java
@@ -86,4 +86,27 @@ public final class TokenResponseFactory {
 
         return map;
     }
+
+    /*
+     * Read raw authorization into a React Native map with codeVerifier value added if present to be passed down the bridge
+     */
+    public static final WritableMap authorizationCodeResponseToMap(AuthorizationResponse authResponse, String codeVerifier) {
+        WritableMap map = Arguments.createMap();
+        map.putString("authorizationCode", authResponse.authorizationCode);
+        map.putString("accessToken", authResponse.accessToken);
+        map.putMap("additionalParameters", MapUtil.createAdditionalParametersMap(authResponse.additionalParameters));
+        map.putString("idToken", authResponse.idToken);
+        map.putString("tokenType", authResponse.tokenType);
+        map.putArray("scopes", createScopeArray(authResponse.scope));
+
+        if (authResponse.accessTokenExpirationTime != null) {
+            map.putString("accessTokenExpirationTime", DateUtil.formatTimestamp(authResponse.accessTokenExpirationTime));
+        }
+
+        if (!TextUtils.isEmpty(codeVerifier)) {
+            map.putString("codeVerifier", codeVerifier);
+        }
+
+        return map;
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,6 +85,7 @@ export interface AuthorizeResult {
   tokenType: string;
   scopes: string[];
   authorizationCode: string;
+  codeVerifier?: string;
 }
 
 export interface RefreshResult {


### PR DESCRIPTION
## Description
The purpose of this PR is to expose/return the `codeVerifier` value that is used in the request when authenticating against a service that uses/requires PKCE and an authorization code is going to be being passed to a server to exchange for tokens.  Both Google and Microsoft recommend using PKCE, and if you do, they require passing the `code_verifier` in the code exchange leg.  For both Android and iOS, I implemented minimal changes to either create and pass the codeVerifier down to the existing library (Android) or just return/expose a value that was already being used (iOS).


