### PR TITLE
Feature/custom http headers on ios

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ with optional overrides.
   - **authorize** - (`{ [key: string]: value }`) headers to be passed during authorization request.
   - **token** - (`{ [key: string]: value }`) headers to be passed during token retrieval request.
   - **register** - (`{ [key: string]: value }`) headers to be passed during registration request.
+- **additionalHeaders** - (`{ [key: string]: value }`) _IOS_ you can specify additional headers to pass for all authorize, token, and register requests.
 - **useNonce** - (`boolean`) _IOS_ (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers
 - **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ with optional overrides.
   - **authorize** - (`{ [key: string]: value }`) headers to be passed during authorization request.
   - **token** - (`{ [key: string]: value }`) headers to be passed during token retrieval request.
   - **register** - (`{ [key: string]: value }`) headers to be passed during registration request.
-- **additionalHeaders** - (`{ [key: string]: value }`) _IOS_ you can specify additional headers to pass for all authorize, token, and register requests.
+- **additionalHeaders** - (`{ [key: string]: value }`) _IOS_ you can specify additional headers to be passed for all authorize, refresh, and register requests.
 - **useNonce** - (`boolean`) _IOS_ (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers
 - **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)

--- a/docs/config-examples/github.md
+++ b/docs/config-examples/github.md
@@ -1,9 +1,5 @@
 # GitHub
 
-** This is Android Only **
-
-Read more about iOS restrictions [here](https://github.com/FormidableLabs/react-native-app-auth/issues/194).
-
 Go to [OAuth Apps](https://github.com/settings/developers) to create your app.
 
 For the Authorization callback URL, choose something like `com.myapp://oauthredirect` and ensure you use `com.myapp` in your `appAuthRedirectScheme` in `android/app/build.gradle`.
@@ -14,6 +10,7 @@ const config = {
   clientId: '<client-id>',
   clientSecret: '<client-secret>',
   scopes: ['identity'],
+  additionalHeaders: { 'Accept': 'application/json' },
   serviceConfiguration: {
     authorizationEndpoint: 'https://github.com/login/oauth/authorize',
     tokenEndpoint: 'https://github.com/login/oauth/access_token',

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,8 @@ type CustomHeaders = {
   register?: Record<string, string>;
 };
 
+type AdditionalHeaders = Record<string, string>;
+
 interface BuiltInRegistrationParameters {
   client_name?: string;
   logo_uri?: string;
@@ -38,6 +40,7 @@ export type RegistrationConfiguration = BaseConfiguration & {
   additionalParameters?: BuiltInRegistrationParameters & { [name: string]: string };
   dangerouslyAllowInsecureHttpRequests?: boolean;
   customHeaders?: CustomHeaders;
+  additionalHeaders?: AdditionalHeaders;
 };
 
 export interface RegistrationResponse {
@@ -69,6 +72,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   clientAuthMethod?: 'basic' | 'post';
   dangerouslyAllowInsecureHttpRequests?: boolean;
   customHeaders?: CustomHeaders;
+  additionalHeaders?: AdditionalHeaders;
   useNonce?: boolean;
   usePKCE?: boolean;
   warmAndPrefetchChrome?: boolean;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import invariant from "invariant"
-import { NativeModules, Platform } from "react-native"
-import base64 from "react-native-base64"
+import invariant from 'invariant';
+import { NativeModules, Platform } from 'react-native';
+import base64 from 'react-native-base64';
 
 const { RNAppAuth } = NativeModules;
 

--- a/index.js
+++ b/index.js
@@ -55,6 +55,20 @@ const validateHeaders = headers => {
   });
 };
 
+const validateAdditionalHeaders = headers => {
+  if (!headers) {
+    return;
+  }
+
+  const errorMessage = 'Config error: additionalHeaders must be { [key: string]: string }';
+
+  invariant(typeof headers === 'object', errorMessage);
+  invariant(
+    Object.values(headers).filter(key => typeof key !== 'string').length === 0,
+    errorMessage
+  );
+};
+
 export const prefetchConfiguration = async ({
   warmAndPrefetchChrome,
   issuer,
@@ -101,6 +115,8 @@ export const register = ({
 }) => {
   validateIssuerOrServiceConfigurationRegistrationEndpoint(issuer, serviceConfiguration);
   validateHeaders(customHeaders);
+  validateAdditionalHeaders(additionalHeaders);
+
   invariant(
     Array.isArray(redirectUrls) && redirectUrls.every(url => typeof url === 'string'),
     'Config error: redirectUrls must be an Array of strings'
@@ -167,6 +183,7 @@ export const authorize = ({
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
   validateHeaders(customHeaders);
+  validateAdditionalHeaders(additionalHeaders);
   // TODO: validateAdditionalParameters
 
   const nativeMethodArguments = [
@@ -216,6 +233,7 @@ export const refresh = (
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
   validateHeaders(customHeaders);
+  validateAdditionalHeaders(additionalHeaders);
   invariant(refreshToken, 'Please pass in a refresh token');
   // TODO: validateAdditionalParameters
 

--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ export const register = ({
   serviceConfiguration,
   dangerouslyAllowInsecureHttpRequests = false,
   customHeaders,
+  additionalHeaders,
 }) => {
   validateIssuerOrServiceConfigurationRegistrationEndpoint(issuer, serviceConfiguration);
   validateHeaders(customHeaders);
@@ -139,6 +140,10 @@ export const register = ({
     nativeMethodArguments.push(customHeaders);
   }
 
+  if (Platform.OS === 'ios') {
+    nativeMethodArguments.push(additionalHeaders);
+  }
+
   return RNAppAuth.register(...nativeMethodArguments);
 };
 
@@ -155,6 +160,7 @@ export const authorize = ({
   clientAuthMethod = 'basic',
   dangerouslyAllowInsecureHttpRequests = false,
   customHeaders,
+  additionalHeaders,
   skipCodeExchange = false,
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
@@ -184,6 +190,7 @@ export const authorize = ({
   if (Platform.OS === 'ios') {
     nativeMethodArguments.push(useNonce);
     nativeMethodArguments.push(usePKCE);
+    nativeMethodArguments.push(additionalHeaders);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);
@@ -201,6 +208,7 @@ export const refresh = (
     clientAuthMethod = 'basic',
     dangerouslyAllowInsecureHttpRequests = false,
     customHeaders,
+    additionalHeaders,
   },
   { refreshToken }
 ) => {
@@ -226,6 +234,10 @@ export const refresh = (
     nativeMethodArguments.push(clientAuthMethod);
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
+  }
+
+  if (Platform.OS === 'ios') {
+    nativeMethodArguments.push(additionalHeaders);
   }
 
   return RNAppAuth.refresh(...nativeMethodArguments);

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-import invariant from 'invariant';
-import { NativeModules, Platform } from 'react-native';
-import base64 from 'react-native-base64';
+import invariant from "invariant"
+import { NativeModules, Platform } from "react-native"
+import base64 from "react-native-base64"
 
 const { RNAppAuth } = NativeModules;
 
@@ -188,9 +188,9 @@ export const authorize = ({
   }
 
   if (Platform.OS === 'ios') {
+    nativeMethodArguments.push(additionalHeaders);
     nativeMethodArguments.push(useNonce);
     nativeMethodArguments.push(usePKCE);
-    nativeMethodArguments.push(additionalHeaders);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);

--- a/index.spec.js
+++ b/index.spec.js
@@ -41,7 +41,7 @@ describe('AppAuth', () => {
     useNonce: true,
     usePKCE: true,
     customHeaders: null,
-    additionalHeaders: { header: "value"},
+    additionalHeaders: { header: 'value'},
     skipCodeExchange: false,
   };
 
@@ -53,7 +53,7 @@ describe('AppAuth', () => {
     subjectType: 'public',
     tokenEndpointAuthMethod: 'client_secret_post',
     additionalParameters: {},
-    additionalHeaders: { header: "value"},
+    additionalHeaders: { header: 'value'},
     serviceConfiguration: null,
   };
 
@@ -192,6 +192,30 @@ describe('AppAuth', () => {
         registerConfig.additionalHeaders
       );
     });
+
+    describe('iOS-specific', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'ios';
+      });
+
+      describe('additionalHeaders parameter', () => {
+        it('calls the native wrapper with additional headers', () => {
+          const additionalHeaders = { header: 'value' };
+          register({ ...registerConfig, additionalHeaders });
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            additionalHeaders
+          );
+        });
+      });
+    })
 
     describe('Android-specific', () => {
       beforeEach(() => {
@@ -418,6 +442,104 @@ describe('AppAuth', () => {
       );
     });
 
+    describe('iOS-specific', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'ios';
+      });
+
+      describe('additionalHeaders parameter', () => {
+        it('calls the native wrapper with additional headers', () => {
+          const additionalHeaders = { header: 'a-value' };
+          authorize({ ...config, additionalHeaders });
+          expect(mockAuthorize).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            config.skipCodeExchange,
+            additionalHeaders,
+            config.useNonce,
+            config.usePKCE,
+          );
+        });  
+      })
+
+      describe('useNonce parameter', () => {
+        it('calls the native wrapper with default value `true`', () => {
+          authorize(config, { refreshToken: 'such-token' });
+          expect(mockAuthorize).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            false,
+            config.additionalHeaders,
+            true,
+            true,
+          );
+        });
+  
+        it('calls the native wrapper with passed value `false`', () => {
+          authorize({ ...config, useNonce: false }, { refreshToken: 'such-token' });
+          expect(mockAuthorize).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            false,
+            config.additionalHeaders,
+            false,
+            true
+          );
+        });
+      });
+  
+      describe('usePKCE parameter', () => {
+        it('calls the native wrapper with default value `true`', () => {
+          authorize(config, { refreshToken: 'such-token' });
+          expect(mockAuthorize).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            config.skipCodeExchange,
+            config.additionalHeaders,
+            config.useNonce,
+            true
+          );
+        });
+  
+        it('calls the native wrapper with passed value `false`', () => {
+          authorize({ ...config, usePKCE: false }, { refreshToken: 'such-token' });
+          expect(mockAuthorize).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            config.skipCodeExchange,
+            config.additionalHeaders,
+            config.useNonce,
+            false
+          );
+        });
+      });
+    });
+
     describe('Android-specific', () => {
       beforeEach(() => {
         require('react-native').Platform.OS = 'android';
@@ -577,6 +699,31 @@ describe('AppAuth', () => {
       );
     });
 
+    describe('iOS-specific', () => {
+      beforeEach(() => {
+        require('react-native').Platform.OS = 'ios';
+      });
+
+      describe('additionalHeaders parameter', () => {
+        it('calls the native wrapper with additional headers', () => {
+          const additionalHeaders = { header: 'value' };
+          const refreshToken = 'a-token';
+          refresh({ ...config, additionalHeaders }, { refreshToken });
+          expect(mockRefresh).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            refreshToken,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            additionalHeaders
+          );
+        });
+      })
+    })
+
     describe('Android-specific', () => {
       beforeEach(() => {
         require('react-native').Platform.OS = 'android';
@@ -585,6 +732,7 @@ describe('AppAuth', () => {
       afterEach(() => {
         require('react-native').Platform.OS = 'ios';
       });
+
       describe(' dangerouslyAllowInsecureHttpRequests parameter', () => {
         it('calls the native wrapper with default value `false`', () => {
           refresh(config, { refreshToken: 'such-token' });
@@ -643,6 +791,7 @@ describe('AppAuth', () => {
           );
         });
       });
+
       describe('customHeaders parameter', () => {
         it('calls the native wrapper with headers', () => {
           const customTokenHeaders = { Authorization: 'Basic someBase64Value' };
@@ -664,86 +813,6 @@ describe('AppAuth', () => {
             customHeaders
           );
         });
-      });
-    });
-
-    describe('iOS-specific useNonce parameter', () => {
-      beforeEach(() => {
-        require('react-native').Platform.OS = 'ios';
-      });
-
-      it('calls the native wrapper with default value `true`', () => {
-        authorize(config, { refreshToken: 'such-token' });
-        expect(mockAuthorize).toHaveBeenCalledWith(
-          config.issuer,
-          config.redirectUrl,
-          config.clientId,
-          config.clientSecret,
-          config.scopes,
-          config.additionalParameters,
-          config.serviceConfiguration,
-          false,
-          config.additionalHeaders,
-          true,
-          true,
-        );
-      });
-
-      it('calls the native wrapper with passed value `false`', () => {
-        authorize({ ...config, useNonce: false }, { refreshToken: 'such-token' });
-        expect(mockAuthorize).toHaveBeenCalledWith(
-          config.issuer,
-          config.redirectUrl,
-          config.clientId,
-          config.clientSecret,
-          config.scopes,
-          config.additionalParameters,
-          config.serviceConfiguration,
-          false,
-          config.additionalHeaders,
-          false,
-          true
-        );
-      });
-    });
-
-    describe('iOS-specific usePKCE parameter', () => {
-      beforeEach(() => {
-        require('react-native').Platform.OS = 'ios';
-      });
-
-      it('calls the native wrapper with default value `true`', () => {
-        authorize(config, { refreshToken: 'such-token' });
-        expect(mockAuthorize).toHaveBeenCalledWith(
-          config.issuer,
-          config.redirectUrl,
-          config.clientId,
-          config.clientSecret,
-          config.scopes,
-          config.additionalParameters,
-          config.serviceConfiguration,
-          config.skipCodeExchange,
-          config.additionalHeaders,
-          config.useNonce,
-          true
-        );
-      });
-
-      it('calls the native wrapper with passed value `false`', () => {
-        authorize({ ...config, usePKCE: false }, { refreshToken: 'such-token' });
-        expect(mockAuthorize).toHaveBeenCalledWith(
-          config.issuer,
-          config.redirectUrl,
-          config.clientId,
-          config.clientSecret,
-          config.scopes,
-          config.additionalParameters,
-          config.serviceConfiguration,
-          config.skipCodeExchange,
-          config.additionalHeaders,
-          config.useNonce,
-          false
-        );
       });
     });
   });

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,4 +1,4 @@
-import { authorize, refresh, register } from "./"
+import { authorize, refresh, register } from './';
 
 jest.mock('react-native', () => ({
   NativeModules: {
@@ -41,7 +41,7 @@ describe('AppAuth', () => {
     useNonce: true,
     usePKCE: true,
     customHeaders: null,
-    additionalHeaders: { header: 'value'},
+    additionalHeaders: { header: 'value' },
     skipCodeExchange: false,
   };
 
@@ -53,7 +53,7 @@ describe('AppAuth', () => {
     subjectType: 'public',
     tokenEndpointAuthMethod: 'client_secret_post',
     additionalParameters: {},
-    additionalHeaders: { header: 'value'},
+    additionalHeaders: { header: 'value' },
     serviceConfiguration: null,
   };
 
@@ -226,7 +226,7 @@ describe('AppAuth', () => {
           }).toThrow();
         });
       });
-    })
+    });
 
     describe('Android-specific', () => {
       beforeEach(() => {
@@ -473,7 +473,7 @@ describe('AppAuth', () => {
             config.skipCodeExchange,
             additionalHeaders,
             config.useNonce,
-            config.usePKCE,
+            config.usePKCE
           );
         });
 
@@ -487,7 +487,7 @@ describe('AppAuth', () => {
             });
           }).toThrow();
         });
-      })
+      });
 
       describe('useNonce parameter', () => {
         it('calls the native wrapper with default value `true`', () => {
@@ -503,10 +503,10 @@ describe('AppAuth', () => {
             false,
             config.additionalHeaders,
             true,
-            true,
+            true
           );
         });
-  
+
         it('calls the native wrapper with passed value `false`', () => {
           authorize({ ...config, useNonce: false }, { refreshToken: 'such-token' });
           expect(mockAuthorize).toHaveBeenCalledWith(
@@ -524,7 +524,7 @@ describe('AppAuth', () => {
           );
         });
       });
-  
+
       describe('usePKCE parameter', () => {
         it('calls the native wrapper with default value `true`', () => {
           authorize(config, { refreshToken: 'such-token' });
@@ -542,7 +542,7 @@ describe('AppAuth', () => {
             true
           );
         });
-  
+
         it('calls the native wrapper with passed value `false`', () => {
           authorize({ ...config, usePKCE: false }, { refreshToken: 'such-token' });
           expect(mockAuthorize).toHaveBeenCalledWith(
@@ -752,8 +752,8 @@ describe('AppAuth', () => {
             );
           }).toThrow();
         });
-      })
-    })
+      });
+    });
 
     describe('Android-specific', () => {
       beforeEach(() => {

--- a/index.spec.js
+++ b/index.spec.js
@@ -214,6 +214,17 @@ describe('AppAuth', () => {
             additionalHeaders
           );
         });
+
+        it('it throws an error when values are not Record<string,string>', () => {
+          expect(() => {
+            register({
+              ...registerConfig,
+              additionalHeaders: {
+                notString: {},
+              },
+            });
+          }).toThrow();
+        });
       });
     })
 
@@ -464,7 +475,18 @@ describe('AppAuth', () => {
             config.useNonce,
             config.usePKCE,
           );
-        });  
+        });
+
+        it('throws an error when values are not Record<string,string>', () => {
+          expect(() => {
+            authorize({
+              ...config,
+              additionalHeaders: {
+                notString: {},
+              },
+            });
+          }).toThrow();
+        });
       })
 
       describe('useNonce parameter', () => {
@@ -720,6 +742,15 @@ describe('AppAuth', () => {
             config.serviceConfiguration,
             additionalHeaders
           );
+        });
+
+        it('throws an error when values are not Record<string,string>', () => {
+          expect(() => {
+            refresh(
+              { ...config, additionalHeaders: { notString: {} } },
+              { refreshToken: 'such-token' }
+            );
+          }).toThrow();
         });
       })
     })

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,4 +1,4 @@
-import { register, authorize, refresh } from './';
+import { authorize, refresh, register } from "./"
 
 jest.mock('react-native', () => ({
   NativeModules: {
@@ -41,6 +41,7 @@ describe('AppAuth', () => {
     useNonce: true,
     usePKCE: true,
     customHeaders: null,
+    additionalHeaders: { header: "value"},
     skipCodeExchange: false,
   };
 
@@ -52,6 +53,7 @@ describe('AppAuth', () => {
     subjectType: 'public',
     tokenEndpointAuthMethod: 'client_secret_post',
     additionalParameters: {},
+    additionalHeaders: { header: "value"},
     serviceConfiguration: null,
   };
 
@@ -186,7 +188,8 @@ describe('AppAuth', () => {
         registerConfig.subjectType,
         registerConfig.tokenEndpointAuthMethod,
         registerConfig.additionalParameters,
-        registerConfig.serviceConfiguration
+        registerConfig.serviceConfiguration,
+        registerConfig.additionalHeaders
       );
     });
 
@@ -382,6 +385,7 @@ describe('AppAuth', () => {
         config.additionalParameters,
         config.serviceConfiguration,
         config.skipCodeExchange,
+        config.additionalHeaders,
         config.useNonce,
         config.usePKCE
       );
@@ -396,6 +400,7 @@ describe('AppAuth', () => {
         customHeaders: null,
         additionalParameters: null,
         serviceConfiguration: null,
+        additionalHeaders: null,
         scopes: ['openid'],
       });
       expect(mockAuthorize).toHaveBeenCalledWith(
@@ -407,6 +412,7 @@ describe('AppAuth', () => {
         null,
         null,
         false,
+        null,
         true,
         true
       );
@@ -566,7 +572,8 @@ describe('AppAuth', () => {
         'such-token',
         config.scopes,
         config.additionalParameters,
-        config.serviceConfiguration
+        config.serviceConfiguration,
+        config.additionalHeaders
       );
     });
 
@@ -676,8 +683,9 @@ describe('AppAuth', () => {
           config.additionalParameters,
           config.serviceConfiguration,
           false,
+          config.additionalHeaders,
           true,
-          true
+          true,
         );
       });
 
@@ -692,6 +700,7 @@ describe('AppAuth', () => {
           config.additionalParameters,
           config.serviceConfiguration,
           false,
+          config.additionalHeaders,
           false,
           true
         );
@@ -714,6 +723,7 @@ describe('AppAuth', () => {
           config.additionalParameters,
           config.serviceConfiguration,
           config.skipCodeExchange,
+          config.additionalHeaders,
           config.useNonce,
           true
         );
@@ -730,6 +740,7 @@ describe('AppAuth', () => {
           config.additionalParameters,
           config.serviceConfiguration,
           config.skipCodeExchange,
+          config.additionalHeaders,
           config.useNonce,
           false
         );

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -44,10 +44,13 @@ RCT_REMAP_METHOD(register,
                  subjectType: (NSString *) subjectType
                  tokenEndpointAuthMethod: (NSString *) tokenEndpointAuthMethod
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
+    [self configureUrlSession:additionalHeaders];
+
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
         OIDServiceConfiguration *configuration = [self createServiceConfiguration:serviceConfiguration];
@@ -87,6 +90,7 @@ RCT_REMAP_METHOD(authorize,
                  clientSecret: (NSString *) clientSecret
                  scopes: (NSArray *) scopes
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  skipCodeExchange: (BOOL) skipCodeExchange
                  useNonce: (BOOL *) useNonce
@@ -94,6 +98,8 @@ RCT_REMAP_METHOD(authorize,
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
+    [self configureUrlSession:additionalHeaders];
+
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
         OIDServiceConfiguration *configuration = [self createServiceConfiguration:serviceConfiguration];
@@ -138,10 +144,13 @@ RCT_REMAP_METHOD(refresh,
                  refreshToken: (NSString *) refreshToken
                  scopes: (NSArray *) scopes
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  resolve:(RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
+    [self configureUrlSession:additionalHeaders];
+
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
         OIDServiceConfiguration *configuration = [self createServiceConfiguration:serviceConfiguration];
@@ -374,6 +383,16 @@ RCT_REMAP_METHOD(refresh,
                                         }];
 }
 
+
+- (void) configureUrlSession: (NSDictionary*) headers {
+    NSURLSessionConfiguration* configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    if (headers != nil) {
+        configuration.HTTPAdditionalHeaders = headers;
+    }
+    
+    NSURLSession* session = [NSURLSession sessionWithConfiguration:configuration];
+    [OIDURLSessionProvider setSession:session];
+}
 
 /*
  * Take raw OIDAuthorizationResponse and turn it to response format to pass to JavaScript caller

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -44,8 +44,8 @@ RCT_REMAP_METHOD(register,
                  subjectType: (NSString *) subjectType
                  tokenEndpointAuthMethod: (NSString *) tokenEndpointAuthMethod
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
-                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
+                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
@@ -90,9 +90,9 @@ RCT_REMAP_METHOD(authorize,
                  clientSecret: (NSString *) clientSecret
                  scopes: (NSArray *) scopes
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
-                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  skipCodeExchange: (BOOL) skipCodeExchange
+                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  useNonce: (BOOL *) useNonce
                  usePKCE: (BOOL *) usePKCE
                  resolve: (RCTPromiseResolveBlock) resolve
@@ -144,8 +144,8 @@ RCT_REMAP_METHOD(refresh,
                  refreshToken: (NSString *) refreshToken
                  scopes: (NSArray *) scopes
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
-                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
+                 additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  resolve:(RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {


### PR DESCRIPTION
# Custom HTTP headers on iOS

## Description

Adds functionality for setting HTTP headers to be sent for authorize, register, and refresh requests on iOS.

The same HTTP headers are sent for all of the requests, which means it does not have the full custom experience as we have on Android, where the HTTP headers can be customized individually for each of the requests. Nevertheless, this is a step forward compared to now, as this will enable sending custom HTTP headers also on iOS.

Feature was originally implemented as a private patch to v5, to meet a requirement in a project I am currently working on, and this pull request has been created from that patch.