### PR TITLE
remove build tools version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,7 +21,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion safeExtGet('compileSdkVersion', 28)
-    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 26)


### PR DESCRIPTION
## Description

Setting buildToolsVersion is no longer recommended, it'll default to Android Gradle Plugin defaults. It makes DX worse by requiring multiple versions of build tools by various dependencies require various versions.

## Steps to verify

<!-- Describe steps to verify -->

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
