### PR TITLE
Android - Changed ActivityResult requestCode to be a value different than 0

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -394,7 +394,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
      */
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-        if (requestCode == 0) {
+        if (requestCode == 52) {
             if (data == null) {
                 if (promise != null) {
                     promise.reject("authentication_error", "Data intent is null" );
@@ -592,10 +592,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             AuthorizationService authService = new AuthorizationService(context, appAuthConfiguration);
             Intent authIntent = authService.getAuthorizationRequestIntent(authRequest);
 
-            currentActivity.startActivityForResult(authIntent, 0);
+            currentActivity.startActivityForResult(authIntent, 52);
         } else {
             AuthorizationService authService = new AuthorizationService(currentActivity, appAuthConfiguration);
-            PendingIntent pendingIntent = currentActivity.createPendingResult(0, new Intent(), 0);
+            PendingIntent pendingIntent = currentActivity.createPendingResult(52, new Intent(), 0);
 
             authService.performAuthorizationRequest(authRequest, pendingIntent);
         }


### PR DESCRIPTION
Android - Changed ActivityResult requestCode to be a value different than 0

Possible fix for #600  

## Description

Changed ActivityResult requestCode to be a value different than 0, as this can cause some unforeseen issues in Andorid and is not a good practice in general.
