### PR TITLE
fix(android): fix an issue with issuer https checks resulting in an i…

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -158,7 +158,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     ) {
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.registrationRequestHeaders);
-        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
+        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
@@ -229,7 +229,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     ) {
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders);
-        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder);
+        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         // store args in private fields for later use in onActivityResult handler
@@ -317,7 +317,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     ) {
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders);
-        final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder);
+        final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         if (clientSecret != null) {
@@ -428,7 +428,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
             final Promise authorizePromise = this.promise;
             final AppAuthConfiguration configuration = createAppAuthConfiguration(
-                    createConnectionBuilder(this.dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders)
+                    createConnectionBuilder(this.dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders),
+                    this.dangerouslyAllowInsecureHttpRequests
             );
 
             AuthorizationService authService = new AuthorizationService(this.reactContext, configuration);
@@ -504,7 +505,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         if (tokenEndpointAuthMethod != null) {
             registrationRequestBuilder.setTokenEndpointAuthenticationMethod(tokenEndpointAuthMethod);
         }
-        
+
         RegistrationRequest registrationRequest = registrationRequestBuilder.build();
 
         AuthorizationService.RegistrationResponseCallback registrationResponseCallback = new AuthorizationService.RegistrationResponseCallback() {
@@ -730,10 +731,14 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     /*
      * Create an App Auth configuration using the provided connection builder
      */
-    private AppAuthConfiguration createAppAuthConfiguration(ConnectionBuilder connectionBuilder) {
+    private AppAuthConfiguration createAppAuthConfiguration(
+            ConnectionBuilder connectionBuilder,
+            Boolean skipIssuerHttpsCheck
+    ) {
         return new AppAuthConfiguration
                 .Builder()
                 .setConnectionBuilder(connectionBuilder)
+                .setSkipIssuerHttpsCheck(skipIssuerHttpsCheck)
                 .build();
     }
 


### PR DESCRIPTION
…nvalid ID token error

## Description

Based on the documentation in openid/AppAuth-Android when allowing http requests `setSkipIssuerHttpsCheck` needs to be called. See the [openid/AppAuth-Android documentation](https://github.com/openid/AppAuth-Android#issues-with-id-token-validation) and [the following issue which documents the issue fixed by this PR](https://github.com/openid/AppAuth-Android/issues/650)

## Steps to verify

On Android:

1. Configure an issuer with an `http` URL.
2. Set `dangerouslyAllowInsecureHttpRequests` in the config.
3. Attempt to login and see the error documented by https://github.com/openid/AppAuth-Android/issues/650
