### PR TITLE
Improve iOS error handling

### DIFF
--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -35,7 +35,7 @@ static NSUInteger const kStateSizeBytes = 32;
 static NSUInteger const kCodeVerifierBytes = 32;
 
 RCT_EXPORT_MODULE()
-    
+
 RCT_REMAP_METHOD(register,
                  issuer: (NSString *) issuer
                  redirectUrls: (NSArray *) redirectUrls
@@ -221,7 +221,7 @@ RCT_REMAP_METHOD(refresh,
   return [OIDTokenUtilities encodeBase64urlNoPadding:sha256Verifier];
 }
 
-    
+
 /*
  * Perform dynamic client registration with provided OIDServiceConfiguration
  */
@@ -239,7 +239,7 @@ RCT_REMAP_METHOD(refresh,
     for (NSString *urlString in redirectUrlStrings) {
         [redirectUrls addObject:[NSURL URLWithString:urlString]];
     }
-    
+
     OIDRegistrationRequest *request =
     [[OIDRegistrationRequest alloc] initWithConfiguration:configuration
                                              redirectURIs:redirectUrls
@@ -248,7 +248,7 @@ RCT_REMAP_METHOD(refresh,
                                               subjectType:subjectType
                                   tokenEndpointAuthMethod:tokenEndpointAuthMethod
                                      additionalParameters:additionalParameters];
-    
+
     [OIDAuthorizationService performRegistrationRequest:request
                                              completion:^(OIDRegistrationResponse *_Nullable response,
                                                           NSError *_Nullable error) {
@@ -260,7 +260,7 @@ RCT_REMAP_METHOD(refresh,
                                                  }
                                             }];
 }
-    
+
 /*
  * Authorize a user in exchange for a token with provided OIDServiceConfiguration
  */
@@ -340,7 +340,8 @@ RCT_REMAP_METHOD(refresh,
                                                         resolve([self formatResponse:authState.lastTokenResponse
                                                             withAuthResponse:authState.lastAuthorizationResponse]);
                                                     } else {
-                                                        reject(@"authentication_failed", [error localizedDescription], error);
+                                                        reject([self getErrorCode: error defaultCode:@"authentication_failed"],
+                                                               [error localizedDescription], error);
                                                     }
                                                 }]; // end [OIDAuthState authStateByPresentingAuthorizationRequest:request
     }
@@ -389,7 +390,7 @@ RCT_REMAP_METHOD(refresh,
     if (headers != nil) {
         configuration.HTTPAdditionalHeaders = headers;
     }
-    
+
     NSURLSession* session = [NSURLSession sessionWithConfiguration:configuration];
     [OIDURLSessionProvider setSession:session];
 }
@@ -466,13 +467,13 @@ RCT_REMAP_METHOD(refresh,
              @"scopes": authResponse.scope ? [authResponse.scope componentsSeparatedByString:@" "] : [NSArray new],
              };
 }
-    
+
 - (NSDictionary*)formatRegistrationResponse: (OIDRegistrationResponse*) response {
     NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
     dateFormat.timeZone = [NSTimeZone timeZoneWithAbbreviation: @"UTC"];
     [dateFormat setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
     [dateFormat setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
-    
+
     return @{@"clientId": response.clientID,
              @"additionalParameters": response.additionalParameters,
              @"clientIdIssuedAt": response.clientIDIssuedAt ? [dateFormat stringFromDate:response.clientIDIssuedAt] : @"",

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -256,7 +256,7 @@ RCT_REMAP_METHOD(refresh,
                                                      resolve([self formatRegistrationResponse:response]);
                                                  } else {
                                                      reject([self getErrorCode: error defaultCode:@"registration_failed"],
-                                                            [error localizedDescription], error);
+                                                            [self getErrorMessage: error], error);
                                                  }
                                             }];
 }
@@ -324,7 +324,7 @@ RCT_REMAP_METHOD(refresh,
                                                            resolve([self formatAuthorizationResponse:authorizationResponse withCodeVerifier:codeVerifier]);
                                                        } else {
                                                            reject([self getErrorCode: error defaultCode:@"authentication_failed"],
-                                                                  [error localizedDescription], error);
+                                                                  [self getErrorMessage: error], error);
                                                        }
                                                    }]; // end [OIDAuthState presentAuthorizationRequest:request
     } else {
@@ -341,7 +341,7 @@ RCT_REMAP_METHOD(refresh,
                                                             withAuthResponse:authState.lastAuthorizationResponse]);
                                                     } else {
                                                         reject([self getErrorCode: error defaultCode:@"authentication_failed"],
-                                                               [error localizedDescription], error);
+                                                               [self getErrorMessage: error], error);
                                                     }
                                                 }]; // end [OIDAuthState authStateByPresentingAuthorizationRequest:request
     }
@@ -379,7 +379,7 @@ RCT_REMAP_METHOD(refresh,
                                                 resolve([self formatResponse:response]);
                                             } else {
                                                 reject([self getErrorCode: error defaultCode:@"token_refresh_failed"],
-                                                       [error localizedDescription], error);
+                                                       [self getErrorMessage: error], error);
                                             }
                                         }];
 }
@@ -530,6 +530,18 @@ RCT_REMAP_METHOD(refresh,
     }
 
     return defaultCode;
+}
+
+- (NSString*)getErrorMessage: (NSError*) error {
+    NSDictionary * userInfo = [error userInfo];
+
+    if (userInfo &&
+        userInfo[OIDOAuthErrorResponseErrorKey] &&
+        userInfo[OIDOAuthErrorResponseErrorKey][OIDOAuthErrorFieldErrorDescription]) {
+        return userInfo[OIDOAuthErrorResponseErrorKey][OIDOAuthErrorFieldErrorDescription];
+    } else {
+        return [error localizedDescription];
+    }
 }
 
 @end


### PR DESCRIPTION
Fixes #653

## Description

The way that callback URI query data is turned into error information by AppAuth-iOS, then subsequently turned into a JavaScript exception by React Native App Auth, causes a divergence in behaviour between Android and iOS. See #653 for details.

This PR takes the `userInfo` dictionary in the `NSError` object and, if it can find a relevant entry, sets the error `message` to match the URI callback query string `error_description` parameter without prefixing or other modification. The prefix of error code was unnecessary, since this value is already present via the JavaScript exception object's `code` attribute.

I note while here that the long implementation of `-getErrorCode:defaultCode` could probably be replaced by just taking the `userInfo` dictionary and reading `[OIDOAuthErrorResponseErrorKey][OIDOAuthErrorFieldError]`, but I don't know the code base well enough to do that (and it'd be another PR anyway).

For reference, see:

* Constants at https://github.com/openid/AppAuth-iOS/blob/master/Source/AppAuthCore/OIDError.m#L39
* Method definition at https://github.com/openid/AppAuth-iOS/blob/master/Source/AppAuthCore/OIDErrorUtilities.m#L63 and `userInfo` dictionary assignment at https://github.com/openid/AppAuth-iOS/blob/master/Source/AppAuthCore/OIDErrorUtilities.m#L78
* Error handling passing in parsed query data (https://github.com/openid/AppAuth-iOS/blob/master/Source/AppAuthCore/OIDAuthorizationService.m#L137) as a dictionary at https://github.com/openid/AppAuth-iOS/blob/master/Source/AppAuthCore/OIDAuthorizationService.m#L142.

## Steps to verify

* Using this branch and some demo app of your choosing, visit an OAuth provider which can redirect back to the callback URL with `error` and `error_description` in the query string and provoke that condition.
* Catch the exception raised by React Native App Auth and inspect the object, noting that the `message` field value now matches the `error_description` URI query parameter value without being prefixed by the OAuth error code in the `error` URI query parameter value.

## A note on testing

There appears to be nothing I can find in the `index.spec.js` file that tests round-trip auth functionality; all tests appear concerned with data types and direct calling interfaces to the library via fairly extensive mocking. Consequently, I've not been able to add tests for the changed behaviour as I'd have to implement anew an entire test system to do that kind of testing, and I've no idea how to approach that... `:-(`