### PR TITLE
Adding support for specifying what browser needs to be used for authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ with optional overrides.
 - **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)
 - **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `SFAuthenticationSession` or `SFSafariViewController` are used.
+- **androidAllowCustomBrowsers** - (`string[]`) (default: undefined) _ANDROID_ override the used browser for authorization. If no value is provided, all browsers are allowed.
 
 #### result
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ with optional overrides.
 - **useNonce** - (`boolean`) (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers
 - **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)
+- **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `SFAuthenticationSession` or `SFSafariViewController` are used.
 
 #### result
 
@@ -331,7 +332,7 @@ Make `AppDelegate` conform to `RNAppAuthAuthorizationFlowManager` with the follo
 + @property(nonatomic, weak)id<RNAppAuthAuthorizationFlowManagerDelegate>authorizationFlowManagerDelegate;
 ```
 
-Add the following code to `AppDelegate.m` (to support iOS <= 10 and React Navigation deep linking)
+Add the following code to `AppDelegate.m` (to support iOS <= 10, React Navigation deep linking and overriding browser behavior in the authorization process)
 
 ```diff
 + - (BOOL)application:(UIApplication *)app openURL:(NSURL *)url options:(NSDictionary<NSString *, id> *) options {

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -241,8 +241,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Promise promise
     ) {
         this.parseHeaderMap(headers);
-        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders, connectionTimeoutMillis, androidAllowCustomBrowsers);
-        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders, connectionTimeoutMillis);
+        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests, androidAllowCustomBrowsers);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         // store args in private fields for later use in onActivityResult handler
@@ -330,11 +330,12 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final String clientAuthMethod,
             final boolean dangerouslyAllowInsecureHttpRequests,
             final ReadableMap headers,
+            final ReadableArray androidAllowCustomBrowsers,
             final Promise promise
     ) {
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders, connectionTimeoutMillis);
-        final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests, null);
+        final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests, androidAllowCustomBrowsers);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         if (clientSecret != null) {
@@ -414,10 +415,11 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableMap serviceConfiguration,
             final ReadableMap additionalParameters,
             final boolean dangerouslyAllowInsecureHttpRequests,
+            final ReadableArray androidAllowCustomBrowsers,
             final Promise promise
     ) {
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, null);
-        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
+        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests, androidAllowCustomBrowsers);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         this.promise = promise;

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.ReadableType;
 
 import com.rnappauth.utils.MapUtil;
+import com.rnappauth.utils.MutableBrowserAllowList;
 import com.rnappauth.utils.UnsafeConnectionBuilder;
 import com.rnappauth.utils.RegistrationResponseFactory;
 import com.rnappauth.utils.TokenResponseFactory;
@@ -45,6 +46,9 @@ import net.openid.appauth.RegistrationResponse;
 import net.openid.appauth.ResponseTypeValues;
 import net.openid.appauth.TokenResponse;
 import net.openid.appauth.TokenRequest;
+import net.openid.appauth.browser.AnyBrowserMatcher;
+import net.openid.appauth.browser.BrowserMatcher;
+import net.openid.appauth.browser.VersionedBrowserMatcher;
 import net.openid.appauth.connectivity.ConnectionBuilder;
 import net.openid.appauth.connectivity.DefaultConnectionBuilder;
 
@@ -159,7 +163,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     ) {
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.registrationRequestHeaders);
-        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
+        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests, null);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         // when serviceConfiguration is provided, we don't need to hit up the OpenID well-known id endpoint
@@ -227,11 +231,12 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final String clientAuthMethod,
             final boolean dangerouslyAllowInsecureHttpRequests,
             final ReadableMap headers,
+            final ReadableArray androidAllowCustomBrowsers,
             final Promise promise
     ) {
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders);
-        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
+        final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests, androidAllowCustomBrowsers);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         // store args in private fields for later use in onActivityResult handler
@@ -322,7 +327,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     ) {
         this.parseHeaderMap(headers);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders);
-        final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
+        final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests, null);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
         if (clientSecret != null) {
@@ -434,7 +439,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Promise authorizePromise = this.promise;
             final AppAuthConfiguration configuration = createAppAuthConfiguration(
                     createConnectionBuilder(this.dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders),
-                    this.dangerouslyAllowInsecureHttpRequests
+                    this.dangerouslyAllowInsecureHttpRequests,
+                    null
             );
 
             AuthorizationService authService = new AuthorizationService(this.reactContext, configuration);
@@ -742,10 +748,12 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
      */
     private AppAuthConfiguration createAppAuthConfiguration(
             ConnectionBuilder connectionBuilder,
-            Boolean skipIssuerHttpsCheck
+            Boolean skipIssuerHttpsCheck,
+            ReadableArray androidAllowCustomBrowsers
     ) {
         return new AppAuthConfiguration
                 .Builder()
+                .setBrowserMatcher(getBrowserAllowList(androidAllowCustomBrowsers))
                 .setConnectionBuilder(connectionBuilder)
                 .setSkipIssuerHttpsCheck(skipIssuerHttpsCheck)
                 .build();
@@ -848,6 +856,50 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         if (issuer != null) {
             mServiceConfigurations.put(issuer, serviceConfiguration);
         }
+    }
+
+    private BrowserMatcher getBrowserAllowList(ReadableArray androidAllowCustomBrowsers) {
+        if(androidAllowCustomBrowsers == null || androidAllowCustomBrowsers.size() == 0) {
+            return AnyBrowserMatcher.INSTANCE;
+        }
+
+        MutableBrowserAllowList browserMatchers = new MutableBrowserAllowList();
+
+        for(int i = 0; i < androidAllowCustomBrowsers.size(); i++) {
+            String browser = androidAllowCustomBrowsers.getString(i);
+
+            if(browser == null) {
+                continue;
+            }
+
+            switch (browser) {
+                case "chrome": {
+                    browserMatchers.add(VersionedBrowserMatcher.CHROME_BROWSER);
+                    break;
+                }
+                case "chromeCustomTab": {
+                    browserMatchers.add(VersionedBrowserMatcher.CHROME_CUSTOM_TAB);
+                    break;
+                }
+                case "firefox": {
+                    browserMatchers.add(VersionedBrowserMatcher.FIREFOX_BROWSER);
+                    break;
+                }
+                case "firefoxCustomTab": {
+                    browserMatchers.add(VersionedBrowserMatcher.FIREFOX_CUSTOM_TAB);
+                    break;
+                }
+                case "samsung": {
+                    browserMatchers.add(VersionedBrowserMatcher.SAMSUNG_BROWSER);
+                    break;
+                }
+                case "samsungCustomTab": {
+                    browserMatchers.add(VersionedBrowserMatcher.SAMSUNG_CUSTOM_TAB);
+                    break;
+                }
+            }
+        }
+        return browserMatchers;
     }
 
     @Override

--- a/android/src/main/java/com/rnappauth/utils/MutableBrowserAllowList.java
+++ b/android/src/main/java/com/rnappauth/utils/MutableBrowserAllowList.java
@@ -1,0 +1,33 @@
+package com.rnappauth.utils;
+
+import androidx.annotation.NonNull;
+
+import net.openid.appauth.browser.BrowserDescriptor;
+import net.openid.appauth.browser.BrowserMatcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MutableBrowserAllowList implements BrowserMatcher {
+
+    private final List<BrowserMatcher> mBrowserMatchers = new ArrayList<>();
+
+    public void add(BrowserMatcher browserMatcher) {
+        mBrowserMatchers.add(browserMatcher);
+    }
+
+    public void remove(BrowserMatcher browserMatcher) {
+        mBrowserMatchers.remove(browserMatcher);
+    }
+
+    @Override
+    public boolean matches(@NonNull BrowserDescriptor descriptor) {
+        for (BrowserMatcher matcher : mBrowserMatchers) {
+            if (matcher.matches(descriptor)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,13 +7,13 @@ export interface ServiceConfiguration {
 
 export type BaseConfiguration =
   | {
-      issuer?: string;
-      serviceConfiguration: ServiceConfiguration;
-    }
+  issuer?: string;
+  serviceConfiguration: ServiceConfiguration;
+}
   | {
-      issuer: string;
-      serviceConfiguration?: ServiceConfiguration;
-    };
+  issuer: string;
+  serviceConfiguration?: ServiceConfiguration;
+};
 
 type CustomHeaders = {
   authorize?: Record<string, string>;
@@ -77,7 +77,8 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   usePKCE?: boolean;
   warmAndPrefetchChrome?: boolean;
   skipCodeExchange?: boolean;
-  iosCustomBrowser?: 'safari' | 'chrome' | 'opera' | 'firefox'
+  iosCustomBrowser?: 'safari' | 'chrome' | 'opera' | 'firefox';
+  androidAllowCustomBrowsers?: ('chrome' | 'chromeCustomTab' | 'firefox' | 'firefoxCustomTab' | 'samsung' | 'samsungCustomTab')[]
 };
 
 export interface AuthorizeResult {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,13 +7,13 @@ export interface ServiceConfiguration {
 
 export type BaseConfiguration =
   | {
-  issuer?: string;
-  serviceConfiguration: ServiceConfiguration;
-}
+      issuer?: string;
+      serviceConfiguration: ServiceConfiguration;
+    }
   | {
-  issuer: string;
-  serviceConfiguration?: ServiceConfiguration;
-};
+      issuer: string;
+      serviceConfiguration?: ServiceConfiguration;
+    };
 
 type CustomHeaders = {
   authorize?: Record<string, string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -77,6 +77,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   usePKCE?: boolean;
   warmAndPrefetchChrome?: boolean;
   skipCodeExchange?: boolean;
+  iosCustomBrowser?: 'safari' | 'chrome' | 'opera' | 'firefox'
 };
 
 export interface AuthorizeResult {

--- a/index.js
+++ b/index.js
@@ -7,21 +7,21 @@ const { RNAppAuth } = NativeModules;
 const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfiguration) =>
   invariant(
     typeof issuer === 'string' ||
-    (serviceConfiguration &&
-      typeof serviceConfiguration.authorizationEndpoint === 'string' &&
-      typeof serviceConfiguration.tokenEndpoint === 'string'),
+      (serviceConfiguration &&
+        typeof serviceConfiguration.authorizationEndpoint === 'string' &&
+        typeof serviceConfiguration.tokenEndpoint === 'string'),
     'Config error: you must provide either an issuer or a service endpoints'
   );
 const validateIssuerOrServiceConfigurationRegistrationEndpoint = (issuer, serviceConfiguration) =>
   invariant(
     typeof issuer === 'string' ||
-    (serviceConfiguration && typeof serviceConfiguration.registrationEndpoint === 'string'),
+      (serviceConfiguration && typeof serviceConfiguration.registrationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a registration endpoint'
   );
 const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>
   invariant(
     typeof issuer === 'string' ||
-    (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
+      (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a revocation endpoint'
   );
 const validateClientId = clientId =>
@@ -41,8 +41,8 @@ const validateHeaders = headers => {
   const correctKeys = keys.filter(key => authorizedKeys.includes(key));
   invariant(
     keys.length <= authorizedKeys.length &&
-    correctKeys.length > 0 &&
-    correctKeys.length === keys.length,
+      correctKeys.length > 0 &&
+      correctKeys.length === keys.length,
     customHeaderTypeErrorMessage
   );
 
@@ -70,15 +70,15 @@ const validateAdditionalHeaders = headers => {
 };
 
 export const prefetchConfiguration = async ({
-                                              warmAndPrefetchChrome,
-                                              issuer,
-                                              redirectUrl,
-                                              clientId,
-                                              scopes,
-                                              serviceConfiguration,
-                                              dangerouslyAllowInsecureHttpRequests = false,
-                                              customHeaders,
-                                            }) => {
+  warmAndPrefetchChrome,
+  issuer,
+  redirectUrl,
+  clientId,
+  scopes,
+  serviceConfiguration,
+  dangerouslyAllowInsecureHttpRequests = false,
+  customHeaders,
+}) => {
   if (Platform.OS === 'android') {
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);
@@ -101,18 +101,18 @@ export const prefetchConfiguration = async ({
 };
 
 export const register = ({
-                           issuer,
-                           redirectUrls,
-                           responseTypes,
-                           grantTypes,
-                           subjectType,
-                           tokenEndpointAuthMethod,
-                           additionalParameters,
-                           serviceConfiguration,
-                           dangerouslyAllowInsecureHttpRequests = false,
-                           customHeaders,
-                           additionalHeaders,
-                         }) => {
+  issuer,
+  redirectUrls,
+  responseTypes,
+  grantTypes,
+  subjectType,
+  tokenEndpointAuthMethod,
+  additionalParameters,
+  serviceConfiguration,
+  dangerouslyAllowInsecureHttpRequests = false,
+  customHeaders,
+  additionalHeaders,
+}) => {
   validateIssuerOrServiceConfigurationRegistrationEndpoint(issuer, serviceConfiguration);
   validateHeaders(customHeaders);
   validateAdditionalHeaders(additionalHeaders);
@@ -123,12 +123,12 @@ export const register = ({
   );
   invariant(
     responseTypes == null ||
-    (Array.isArray(responseTypes) && responseTypes.every(rt => typeof rt === 'string')),
+      (Array.isArray(responseTypes) && responseTypes.every(rt => typeof rt === 'string')),
     'Config error: if provided, responseTypes must be an Array of strings'
   );
   invariant(
     grantTypes == null ||
-    (Array.isArray(grantTypes) && grantTypes.every(gt => typeof gt === 'string')),
+      (Array.isArray(grantTypes) && grantTypes.every(gt => typeof gt === 'string')),
     'Config error: if provided, grantTypes must be an Array of strings'
   );
   invariant(
@@ -164,23 +164,23 @@ export const register = ({
 };
 
 export const authorize = ({
-                            issuer,
-                            redirectUrl,
-                            clientId,
-                            clientSecret,
-                            scopes,
-                            useNonce = true,
-                            usePKCE = true,
-                            additionalParameters,
-                            serviceConfiguration,
-                            clientAuthMethod = 'basic',
-                            dangerouslyAllowInsecureHttpRequests = false,
-                            customHeaders,
-                            additionalHeaders,
-                            skipCodeExchange = false,
-                            iosCustomBrowser = null,
-                            androidAllowCustomBrowsers = null
-                          }) => {
+  issuer,
+  redirectUrl,
+  clientId,
+  clientSecret,
+  scopes,
+  useNonce = true,
+  usePKCE = true,
+  additionalParameters,
+  serviceConfiguration,
+  clientAuthMethod = 'basic',
+  dangerouslyAllowInsecureHttpRequests = false,
+  customHeaders,
+  additionalHeaders,
+  skipCodeExchange = false,
+  iosCustomBrowser = null,
+  androidAllowCustomBrowsers = null
+}) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
@@ -230,7 +230,7 @@ export const refresh = (
     clientAuthMethod = 'basic',
     dangerouslyAllowInsecureHttpRequests = false,
     customHeaders,
-    additionalHeaders
+    additionalHeaders,
   },
   { refreshToken }
 ) => {
@@ -296,11 +296,11 @@ export const revoke = async (
     headers.Authorization = `Basic ${base64.encode(`${clientId}:${clientSecret}`)}`;
   }
   /**
-   Identity Server insists on client_id being passed in the body,
-   but Google does not. According to the spec, Google is right
-   so defaulting to no client_id
-   https://tools.ietf.org/html/rfc7009#section-2.1
-   **/
+    Identity Server insists on client_id being passed in the body,
+    but Google does not. According to the spec, Google is right
+    so defaulting to no client_id
+    https://tools.ietf.org/html/rfc7009#section-2.1
+  **/
   return await fetch(revocationEndpoint, {
     method: 'POST',
     headers,

--- a/index.js
+++ b/index.js
@@ -7,21 +7,21 @@ const { RNAppAuth } = NativeModules;
 const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfiguration) =>
   invariant(
     typeof issuer === 'string' ||
-      (serviceConfiguration &&
-        typeof serviceConfiguration.authorizationEndpoint === 'string' &&
-        typeof serviceConfiguration.tokenEndpoint === 'string'),
+    (serviceConfiguration &&
+      typeof serviceConfiguration.authorizationEndpoint === 'string' &&
+      typeof serviceConfiguration.tokenEndpoint === 'string'),
     'Config error: you must provide either an issuer or a service endpoints'
   );
 const validateIssuerOrServiceConfigurationRegistrationEndpoint = (issuer, serviceConfiguration) =>
   invariant(
     typeof issuer === 'string' ||
-      (serviceConfiguration && typeof serviceConfiguration.registrationEndpoint === 'string'),
+    (serviceConfiguration && typeof serviceConfiguration.registrationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a registration endpoint'
   );
 const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>
   invariant(
     typeof issuer === 'string' ||
-      (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
+    (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a revocation endpoint'
   );
 const validateClientId = clientId =>
@@ -41,8 +41,8 @@ const validateHeaders = headers => {
   const correctKeys = keys.filter(key => authorizedKeys.includes(key));
   invariant(
     keys.length <= authorizedKeys.length &&
-      correctKeys.length > 0 &&
-      correctKeys.length === keys.length,
+    correctKeys.length > 0 &&
+    correctKeys.length === keys.length,
     customHeaderTypeErrorMessage
   );
 
@@ -70,15 +70,15 @@ const validateAdditionalHeaders = headers => {
 };
 
 export const prefetchConfiguration = async ({
-  warmAndPrefetchChrome,
-  issuer,
-  redirectUrl,
-  clientId,
-  scopes,
-  serviceConfiguration,
-  dangerouslyAllowInsecureHttpRequests = false,
-  customHeaders,
-}) => {
+                                              warmAndPrefetchChrome,
+                                              issuer,
+                                              redirectUrl,
+                                              clientId,
+                                              scopes,
+                                              serviceConfiguration,
+                                              dangerouslyAllowInsecureHttpRequests = false,
+                                              customHeaders,
+                                            }) => {
   if (Platform.OS === 'android') {
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
     validateClientId(clientId);
@@ -101,18 +101,18 @@ export const prefetchConfiguration = async ({
 };
 
 export const register = ({
-  issuer,
-  redirectUrls,
-  responseTypes,
-  grantTypes,
-  subjectType,
-  tokenEndpointAuthMethod,
-  additionalParameters,
-  serviceConfiguration,
-  dangerouslyAllowInsecureHttpRequests = false,
-  customHeaders,
-  additionalHeaders,
-}) => {
+                           issuer,
+                           redirectUrls,
+                           responseTypes,
+                           grantTypes,
+                           subjectType,
+                           tokenEndpointAuthMethod,
+                           additionalParameters,
+                           serviceConfiguration,
+                           dangerouslyAllowInsecureHttpRequests = false,
+                           customHeaders,
+                           additionalHeaders,
+                         }) => {
   validateIssuerOrServiceConfigurationRegistrationEndpoint(issuer, serviceConfiguration);
   validateHeaders(customHeaders);
   validateAdditionalHeaders(additionalHeaders);
@@ -123,12 +123,12 @@ export const register = ({
   );
   invariant(
     responseTypes == null ||
-      (Array.isArray(responseTypes) && responseTypes.every(rt => typeof rt === 'string')),
+    (Array.isArray(responseTypes) && responseTypes.every(rt => typeof rt === 'string')),
     'Config error: if provided, responseTypes must be an Array of strings'
   );
   invariant(
     grantTypes == null ||
-      (Array.isArray(grantTypes) && grantTypes.every(gt => typeof gt === 'string')),
+    (Array.isArray(grantTypes) && grantTypes.every(gt => typeof gt === 'string')),
     'Config error: if provided, grantTypes must be an Array of strings'
   );
   invariant(
@@ -164,22 +164,23 @@ export const register = ({
 };
 
 export const authorize = ({
-  issuer,
-  redirectUrl,
-  clientId,
-  clientSecret,
-  scopes,
-  useNonce = true,
-  usePKCE = true,
-  additionalParameters,
-  serviceConfiguration,
-  clientAuthMethod = 'basic',
-  dangerouslyAllowInsecureHttpRequests = false,
-  customHeaders,
-  additionalHeaders,
-  skipCodeExchange = false,
-  iosCustomBrowser = null,
-}) => {
+                            issuer,
+                            redirectUrl,
+                            clientId,
+                            clientSecret,
+                            scopes,
+                            useNonce = true,
+                            usePKCE = true,
+                            additionalParameters,
+                            serviceConfiguration,
+                            clientAuthMethod = 'basic',
+                            dangerouslyAllowInsecureHttpRequests = false,
+                            customHeaders,
+                            additionalHeaders,
+                            skipCodeExchange = false,
+                            iosCustomBrowser = null,
+                            androidAllowCustomBrowsers = null
+                          }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
   validateRedirectUrl(redirectUrl);
@@ -204,6 +205,7 @@ export const authorize = ({
     nativeMethodArguments.push(clientAuthMethod);
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
+    nativeMethodArguments.push(androidAllowCustomBrowsers);
   }
 
   if (Platform.OS === 'ios') {
@@ -228,7 +230,7 @@ export const refresh = (
     clientAuthMethod = 'basic',
     dangerouslyAllowInsecureHttpRequests = false,
     customHeaders,
-    additionalHeaders,
+    additionalHeaders
   },
   { refreshToken }
 ) => {
@@ -294,11 +296,11 @@ export const revoke = async (
     headers.Authorization = `Basic ${base64.encode(`${clientId}:${clientSecret}`)}`;
   }
   /**
-    Identity Server insists on client_id being passed in the body,
-    but Google does not. According to the spec, Google is right
-    so defaulting to no client_id
-    https://tools.ietf.org/html/rfc7009#section-2.1
-  **/
+   Identity Server insists on client_id being passed in the body,
+   but Google does not. According to the spec, Google is right
+   so defaulting to no client_id
+   https://tools.ietf.org/html/rfc7009#section-2.1
+   **/
   return await fetch(revocationEndpoint, {
     method: 'POST',
     headers,

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ export const authorize = ({
   additionalHeaders,
   skipCodeExchange = false,
   iosCustomBrowser = null,
-  androidAllowCustomBrowsers = null
+  androidAllowCustomBrowsers = null,
   connectionTimeoutSeconds,
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);

--- a/index.js
+++ b/index.js
@@ -178,6 +178,7 @@ export const authorize = ({
   customHeaders,
   additionalHeaders,
   skipCodeExchange = false,
+  iosCustomBrowser = null,
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
@@ -209,6 +210,7 @@ export const authorize = ({
     nativeMethodArguments.push(additionalHeaders);
     nativeMethodArguments.push(useNonce);
     nativeMethodArguments.push(usePKCE);
+    nativeMethodArguments.push(iosCustomBrowser);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);

--- a/index.js
+++ b/index.js
@@ -263,6 +263,8 @@ export const refresh = (
     dangerouslyAllowInsecureHttpRequests = false,
     customHeaders,
     additionalHeaders,
+    iosCustomBrowser = null,
+    androidAllowCustomBrowsers = null,
     connectionTimeoutSeconds,
   },
   { refreshToken }
@@ -292,10 +294,12 @@ export const refresh = (
     nativeMethodArguments.push(clientAuthMethod);
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
+    nativeMethodArguments.push(androidAllowCustomBrowsers);
   }
 
   if (Platform.OS === 'ios') {
     nativeMethodArguments.push(additionalHeaders);
+    nativeMethodArguments.push(iosCustomBrowser);
   }
 
   return RNAppAuth.refresh(...nativeMethodArguments);
@@ -351,6 +355,8 @@ export const logout = (
     serviceConfiguration,
     additionalParameters,
     dangerouslyAllowInsecureHttpRequests = false,
+    iosCustomBrowser = null,
+    androidAllowCustomBrowsers = null,
   },
   { idToken, postLogoutRedirectUrl }
 ) => {
@@ -368,6 +374,11 @@ export const logout = (
 
   if (Platform.OS === 'android') {
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
+    nativeMethodArguments.push(androidAllowCustomBrowsers);
+  }
+
+  if (Platform.OS === 'ios') {
+    nativeMethodArguments.push(iosCustomBrowser);
   }
 
   return RNAppAuth.logout(...nativeMethodArguments);

--- a/index.spec.js
+++ b/index.spec.js
@@ -60,6 +60,8 @@ describe('AppAuth', () => {
     additionalHeaders: { header: 'value' },
     connectionTimeoutSeconds: TIMEOUT_SEC,
     skipCodeExchange: false,
+    iosCustomBrowser: 'safari',
+    androidAllowCustomBrowsers: ['chrome'],
   };
 
   const registerConfig = {
@@ -530,7 +532,8 @@ describe('AppAuth', () => {
         config.connectionTimeoutSeconds,
         config.additionalHeaders,
         config.useNonce,
-        config.usePKCE
+        config.usePKCE,
+        config.iosCustomBrowser
       );
     });
 
@@ -558,7 +561,8 @@ describe('AppAuth', () => {
         DEFAULT_TIMEOUT_IOS,
         null,
         true,
-        true
+        true,
+        null
       );
     });
 
@@ -582,7 +586,8 @@ describe('AppAuth', () => {
             config.connectionTimeoutSeconds,
             config.additionalHeaders,
             config.useNonce,
-            config.usePKCE
+            config.usePKCE,
+            config.iosCustomBrowser
           );
         });
       });
@@ -603,7 +608,8 @@ describe('AppAuth', () => {
             config.connectionTimeoutSeconds,
             additionalHeaders,
             config.useNonce,
-            config.usePKCE
+            config.usePKCE,
+            config.iosCustomBrowser
           );
         });
 
@@ -634,7 +640,8 @@ describe('AppAuth', () => {
             config.connectionTimeoutSeconds,
             config.additionalHeaders,
             true,
-            true
+            true,
+            config.iosCustomBrowser
           );
         });
 
@@ -652,7 +659,8 @@ describe('AppAuth', () => {
             config.connectionTimeoutSeconds,
             config.additionalHeaders,
             false,
-            true
+            true,
+            config.iosCustomBrowser
           );
         });
       });
@@ -672,7 +680,8 @@ describe('AppAuth', () => {
             config.connectionTimeoutSeconds,
             config.additionalHeaders,
             config.useNonce,
-            true
+            true,
+            config.iosCustomBrowser
           );
         });
 
@@ -690,7 +699,8 @@ describe('AppAuth', () => {
             config.connectionTimeoutSeconds,
             config.additionalHeaders,
             config.useNonce,
-            false
+            false,
+            config.iosCustomBrowser
           );
         });
       });
@@ -718,7 +728,8 @@ describe('AppAuth', () => {
             config.usePKCE,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
       });
@@ -740,7 +751,8 @@ describe('AppAuth', () => {
             config.usePKCE,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
 
@@ -760,7 +772,8 @@ describe('AppAuth', () => {
             config.usePKCE,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
 
@@ -780,7 +793,8 @@ describe('AppAuth', () => {
             config.usePKCE,
             config.clientAuthMethod,
             true,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
       });
@@ -809,7 +823,8 @@ describe('AppAuth', () => {
             config.usePKCE,
             config.clientAuthMethod,
             false,
-            customHeaders
+            customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
       });

--- a/index.spec.js
+++ b/index.spec.js
@@ -902,7 +902,8 @@ describe('AppAuth', () => {
         config.additionalParameters,
         config.serviceConfiguration,
         config.connectionTimeoutSeconds,
-        config.additionalHeaders
+        config.additionalHeaders,
+        config.iosCustomBrowser
       );
     });
 
@@ -924,7 +925,8 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             config.connectionTimeoutSeconds,
-            config.additionalHeaders
+            config.additionalHeaders,
+            config.iosCustomBrowser
           );
         });
       });
@@ -943,7 +945,8 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             config.connectionTimeoutSeconds,
-            additionalHeaders
+            additionalHeaders,
+            config.iosCustomBrowser
           );
         });
 
@@ -975,7 +978,8 @@ describe('AppAuth', () => {
             TIMEOUT_MILLIS,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
       });
@@ -995,7 +999,8 @@ describe('AppAuth', () => {
             TIMEOUT_MILLIS,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
 
@@ -1013,7 +1018,8 @@ describe('AppAuth', () => {
             TIMEOUT_MILLIS,
             config.clientAuthMethod,
             false,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
 
@@ -1031,7 +1037,8 @@ describe('AppAuth', () => {
             TIMEOUT_MILLIS,
             config.clientAuthMethod,
             true,
-            config.customHeaders
+            config.customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
       });
@@ -1054,7 +1061,8 @@ describe('AppAuth', () => {
             TIMEOUT_MILLIS,
             config.clientAuthMethod,
             false,
-            customHeaders
+            customHeaders,
+            config.androidAllowCustomBrowsers
           );
         });
       });
@@ -1111,7 +1119,8 @@ describe('AppAuth', () => {
           '_token_',
           '_redirect_',
           config.serviceConfiguration,
-          config.additionalParameters
+          config.additionalParameters,
+          config.iosCustomBrowser
         );
       });
     });
@@ -1129,7 +1138,8 @@ describe('AppAuth', () => {
           '_redirect_',
           config.serviceConfiguration,
           config.additionalParameters,
-          false
+          false,
+          config.androidAllowCustomBrowsers
         );
       });
 
@@ -1144,7 +1154,8 @@ describe('AppAuth', () => {
           '_redirect_',
           config.serviceConfiguration,
           config.additionalParameters,
-          true
+          true,
+          config.androidAllowCustomBrowsers
         );
       });
 
@@ -1159,7 +1170,8 @@ describe('AppAuth', () => {
           '_redirect_',
           config.serviceConfiguration,
           config.additionalParameters,
-          false
+          false,
+          config.androidAllowCustomBrowsers
         );
       });
     });


### PR DESCRIPTION
This fixes #588 and #643 

## Description

<!-- Include a summary of the work -->
This pull request adds the ability to control what browser is used for the authorization process. This helps in complex flows where the authorization is going through a browser and has a sidestep to a third party app.

In our case we were encountering issues, because third party apps use the default browser for return urls, but the in-app browser (Such as `aswebauthenticationsession`) doesn't share cookies with Safari.
By providing these parameters, the developers can fine-tune the login flow for their needs.


**Question for the maintainers:**
I'm not an iOS developer, and am seeing one flaw in the user flow when using an external browser:
If the user cancels the flow by pressing the "back" navigation on the top left of the browser, the promise isn't rejected. Do you have any idea how i can fix this? On Android, the promise is rejected when returning (which is expected)


## Steps to verify

<!-- Describe steps to verify -->
On iOS: 
 - Adding `iosCustomBrowser` with the value `safari` should open safari, instead of a browser modal. 
 - Without providing `iosCustomBrowser`, the behavior should remain the same as before this pull request

On Android:
 - Adding `androidAllowCustomBrowsers` with the value ['chrome'] should open chrome, instead of the in-app browser
 - Without providing `androidAllowCustomBrowsers`, the behavior should remain the same as before this pull request

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
