### PR TITLE
Readme should mention that `appAuthRedirectScheme` must be lowercased for application be able to catch authorization redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ android {
 ```
 
 The scheme is the beginning of your OAuth Redirect URL, up to the scheme separator (`:`) character. E.g. if your redirect uri
-is `com.myapp://oauth`, then the url scheme will is `com.myapp`.
+is `com.myapp://oauth`, then the url scheme will is `com.myapp`. The scheme must be in lowercase.
 
 NOTE: When integrating with [React Navigation deep linking](https://reactnavigation.org/docs/deep-linking/#set-up-with-bare-react-native-projects), be sure to make this scheme (and the scheme in the config's redirectUrl) unique from the scheme defined in the deep linking intent-filter. E.g. if the scheme in your intent-filter is set to `com.myapp`, then update the above scheme/redirectUrl to be `com.myapp.auth` [as seen here](https://github.com/FormidableLabs/react-native-app-auth/issues/494#issuecomment-797394994).
 


### PR DESCRIPTION
## Description

I was working on migrating existing iOS application to react-native and encountered a problem which took some time for me to debug, so I hope this small readme update can save time for people in similar situation.

The problem was that I had existing `redirectUrl` specified in uppercase like this: 
```js
export const AUTH_CONFIG = {
  // ...
  redirectUrl: `COMPANY://audits`,
}
```

Following the [docs for react-native-app-auth](https://github.com/FormidableLabs/react-native-app-auth#android-setup) I have to assign `appAuthRedirectScheme` as a `COMPANY` part of the redirectUrl:
>The scheme is the beginning of your OAuth Redirect URL, up to the scheme separator (`:`) character. E.g. if your redirect uri
is `com.myapp://oauth`, then the url scheme will is `com.myapp`.

But by following this instructions my application failed to catch authorization redirect from sso page to my application.  
In fact, although redirectUrl is case-insensitive, `appAuthRedirectScheme` **is not**: it is a placeholder variable for `<data  android:scheme />` element in [AppAuth-Android RedirectUriReceiverActivity](https://github.com/openid/AppAuth-Android/blob/26b37115b1d4e7da7b63ca5bf98f447d174e131e/library/AndroidManifest.xml#L31), and the value of this tag should be **lowercased** according to [official Android guide to app manifest](https://developer.android.com/guide/topics/manifest/data-element#:~:text=case-sensitive%2C%20unlike%20the%20RFC).

```gradle
android {
    defaultConfig {
        manifestPlaceholders = [
               // 'appAuthRedirectScheme': 'COMPANY' << incorrect
               'appAuthRedirectScheme': 'company' // << correct
        ]
    }
```

There are existing issues mentioning this problem in other libraries using `net.openid:appauth` (e.g. https://github.com/openid/AppAuth-Android/issues/533#issuecomment-649006489, https://github.com/MaikuB/flutter_appauth/issues/127#issuecomment-648962230 or [stackoverflow](https://stackoverflow.com/questions/62543099/appauth-login-redirection-works-on-ios-but-not-on-android)), but it's very hard to catch without knowing how `appAuthRedirectScheme` is used internally.