### PR TITLE
fix: code_verifier error in Spotify example

### DIFF
--- a/docs/config-examples/spotify.md
+++ b/docs/config-examples/spotify.md
@@ -37,6 +37,7 @@ const config = {
     authorizationEndpoint: 'https://accounts.spotify.com/authorize',
     tokenEndpoint: 'https://my-token-service/api/token',
   },
+  usePKCE: false,
 };
 
 const authState = await authorize(config);


### PR DESCRIPTION
## Description
The custom token service will currently return an error stating that the code_verifier is missing.
The flow with PKCE requires you to send an extra param: code_verifier, which the backend service isn't handling.

Spotify advises to use the code flow (without PKCE) when you have a backend service that doesn't expose the client secret.

**Sources:**
https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow
_This flow is suitable for long-running applications in which the user grants permission only once. It provides an access token that can be refreshed. Since the token exchange involves sending your secret key, perform this on a secure location, like a backend service, and not from a client such as a browser or from a mobile app._

https://developer.spotify.com/documentation/general/guides/authorization-guide/#authorization-code-flow-with-proof-key-for-code-exchange-pkce
_The authorization code flow with PKCE is the best option for mobile and desktop applications where it is unsafe to store your client secret. It provides your app with an access token that can be refreshed._
