### PR TITLE
OpenID Connect RP Initiated Logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ with optional overrides.
   - **tokenEndpoint** - (`string`) _REQUIRED_ fully formed url to the OAuth token exchange endpoint
   - **revocationEndpoint** - (`string`) fully formed url to the OAuth token revocation endpoint. If you want to be able to revoke a token and no `issuer` is specified, this field is mandatory.
   - **registrationEndpoint** - (`string`) fully formed url to your OAuth/OpenID Connect registration endpoint. Only necessary for servers that require client registration.
+  - **endSessionEndpoint** - (`string`) fully formed url to your OpenID Connect end session endpoint. If you want to be able to end a user's session and no `issuer` is specified, this field is mandatory.
 - **clientId** - (`string`) _REQUIRED_ your client id on the auth server
 - **clientSecret** - (`string`) client secret to pass to token exchange requests. :warning: Read more about [client secrets](#note-about-client-secrets)
 - **redirectUrl** - (`string`) _REQUIRED_ the url that links back to your app with the auth code
@@ -189,6 +190,23 @@ const result = await revoke(config, {
   tokenToRevoke: `<TOKEN_TO_REVOKE>`,
   includeBasicAuth: true,
   sendClientId: true,
+});
+```
+
+### `logout`
+
+This method will logout a user, as per the [OpenID Connect RP Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) specification. It requires an `idToken`, obtained after successfully authenticating with OpenID Connect, and a URL to redirect back after the logout has been performed.
+
+```js
+import { logout } from 'react-native-app-auth';
+
+const config = {
+  issuer: '<YOUR_ISSUER_URL>'
+};
+
+const result = await logout(config, {
+  idToken: '<ID_TOKEN>',
+  postLogoutRedirectUrl: '<POST_LOGOUT_URL>'
 });
 ```
 

--- a/android/src/main/java/com/rnappauth/utils/EndSessionResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/EndSessionResponseFactory.java
@@ -1,0 +1,21 @@
+package com.rnappauth.utils;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableMap;
+
+import net.openid.appauth.EndSessionResponse;
+
+public final class EndSessionResponseFactory {
+    /*
+     * Read raw end session response into a React Native map to be passed down the bridge
+     */
+    public static final WritableMap endSessionResponseToMap(EndSessionResponse response) {
+        WritableMap map = Arguments.createMap();
+
+        map.putString("state", response.state);
+        map.putString("idTokenHint", response.request.idToken);
+        map.putString("postLogoutRedirectUri", response.request.redirectUri.toString());
+
+        return map;
+    }
+}

--- a/docs/config-examples/okta.md
+++ b/docs/config-examples/okta.md
@@ -33,7 +33,7 @@ await revoke(config, {
 
 // End session
 await logout(config, {
-  idTokenHint: authState.idToken,
+  idToken: authState.idToken,
   postLogoutRedirectUrl: 'com.{yourReversedOktaDomain}:/logout'
 });
 ```

--- a/docs/config-examples/okta.md
+++ b/docs/config-examples/okta.md
@@ -7,6 +7,8 @@ Full support out of the box.
 > Log in to your Okta Developer account and navigate to **Applications** > **Add Application**. Click **Native** and click the **Next** button. Give the app a name you’ll remember (e.g., `React Native`), select `Refresh Token` as a grant type, in addition to the default `Authorization Code`. Copy the **Login redirect URI** (e.g., `com.oktapreview.dev-158606:/callback`) and save it somewhere. You'll need this value when configuring your app.
 >
 > Click **Done** and you'll see a client ID on the next screen. Copy the redirect URI and clientId values into your App Auth config.
+>
+> To end the session, `postLogoutRedirectUrl` has to be one of the **Sign-out redirect URIs** defined in the **General Settings** > **LOGIN** section of the application page previously created.
 
 ```js
 const config = {
@@ -27,5 +29,11 @@ const refreshedState = await refresh(config, {
 // Revoke token
 await revoke(config, {
   tokenToRevoke: refreshedState.refreshToken
+});
+
+// End session
+await logout(config, {
+  idTokenHint: authState.idToken,
+  postLogoutRedirectUrl: 'com.{yourReversedOktaDomain}:/logout'
 });
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,7 @@ export interface ServiceConfiguration {
   tokenEndpoint: string;
   revocationEndpoint?: string;
   registrationEndpoint?: string;
+  endSessionEndpoint?: string;
 }
 
 export type BaseConfiguration =
@@ -79,6 +80,11 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   skipCodeExchange?: boolean;
 };
 
+export type EndSessionConfiguration = BaseAuthConfiguration & {
+  additionalParameters?: { [name: string]: string };
+  dangerouslyAllowInsecureHttpRequests?: boolean;
+};
+
 export interface AuthorizeResult {
   accessToken: string;
   accessTokenExpirationDate: string;
@@ -111,6 +117,17 @@ export interface RefreshConfiguration {
   refreshToken: string;
 }
 
+export interface LogoutConfiguration {
+  idToken: string;
+  postLogoutRedirectUrl: string;
+}
+
+export interface EndSessionResult {
+  idTokenHint: string;
+  postLogoutRedirectUri: string;
+  state: string;
+}
+
 export function prefetchConfiguration(config: AuthConfiguration): Promise<void>;
 
 export function register(config: RegistrationConfiguration): Promise<RegistrationResponse>;
@@ -126,6 +143,11 @@ export function revoke(
   config: BaseAuthConfiguration,
   revokeConfig: RevokeConfiguration
 ): Promise<void>;
+
+export function logout(
+  config: EndSessionConfiguration,
+  logoutConfig: LogoutConfiguration
+): Promise<EndSessionResult>;
 
 // https://tools.ietf.org/html/rfc6749#section-4.1.2.1
 type OAuthAuthorizationErrorCode =
@@ -150,7 +172,8 @@ type AppAuthErrorCode =
   | 'authentication_failed'
   | 'token_refresh_failed'
   | 'registration_failed'
-  | 'browser_not_found';
+  | 'browser_not_found'
+  | 'end_session_failed';
 
 type ErrorCode =
   | OAuthAuthorizationErrorCode

--- a/index.js
+++ b/index.js
@@ -24,6 +24,12 @@ const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceC
       (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a revocation endpoint'
   );
+const validateIssuerOrServiceConfigurationEndSessionEndpoint = (issuer, serviceConfiguration) =>
+  invariant(
+    typeof issuer === 'string' ||
+      (serviceConfiguration && typeof serviceConfiguration.endSessionEndpoint === 'string'),
+    'Config error: you must provide either an issuer or an end session endpoint'
+  );
 const validateClientId = clientId =>
   invariant(typeof clientId === 'string', 'Config error: clientId must be a string');
 const validateRedirectUrl = redirectUrl =>
@@ -304,4 +310,32 @@ export const revoke = async (
   }).catch(error => {
     throw new Error('Failed to revoke token', error);
   });
+};
+
+export const logout = (
+  {
+    issuer,
+    serviceConfiguration,
+    additionalParameters,
+    dangerouslyAllowInsecureHttpRequests = false,
+  },
+  { idToken, postLogoutRedirectUrl }
+) => {
+  validateIssuerOrServiceConfigurationEndSessionEndpoint(issuer, serviceConfiguration);
+  validateRedirectUrl(postLogoutRedirectUrl);
+  invariant(idToken, 'Please pass in the ID token');
+
+  const nativeMethodArguments = [
+    issuer,
+    idToken,
+    postLogoutRedirectUrl,
+    serviceConfiguration,
+    additionalParameters,
+  ];
+
+  if (Platform.OS === 'android') {
+    nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
+  }
+
+  return RNAppAuth.logout(...nativeMethodArguments);
 };

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -442,9 +442,9 @@ RCT_REMAP_METHOD(logout,
     appDelegate.authorizationFlowManagerDelegate = self;
     __weak typeof(self) weakSelf = self;
 
-    taskId = [UIApplication.sharedApplication beginBackgroundTaskWithExpirationHandler:^{
-        [UIApplication.sharedApplication endBackgroundTask:taskId];
-        taskId = UIBackgroundTaskInvalid;
+    rnAppAuthTaskId = [UIApplication.sharedApplication beginBackgroundTaskWithExpirationHandler:^{
+        [UIApplication.sharedApplication endBackgroundTask:rnAppAuthTaskId];
+        rnAppAuthTaskId = UIBackgroundTaskInvalid;
     }];
 
     UIViewController *presentingViewController = appDelegate.window.rootViewController.view.window ? appDelegate.window.rootViewController : appDelegate.window.rootViewController.presentedViewController;
@@ -454,8 +454,8 @@ RCT_REMAP_METHOD(logout,
                                              callback: ^(OIDEndSessionResponse *_Nullable response, NSError *_Nullable error) {
                                                           typeof(self) strongSelf = weakSelf;
                                                           strongSelf->_currentSession = nil;
-                                                          [UIApplication.sharedApplication endBackgroundTask:taskId];
-                                                          taskId = UIBackgroundTaskInvalid;
+                                                          [UIApplication.sharedApplication endBackgroundTask:rnAppAuthTaskId];
+                                                          rnAppAuthTaskId = UIBackgroundTaskInvalid;
                                                           if (response) {
                                                               resolve([self formatEndSessionResponse:response]);
                                                           } else {


### PR DESCRIPTION
Fixes #621 #68 

## Description

This pull request adds the **OIDC RP initiated logout** (link to the [specification](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)). Now it should be possible to properly logout a user, avoiding the automatic login after a simple token revocation.

The feature has already been developed on the native AppAuth libraries, for [Android](https://github.com/openid/AppAuth-Android/pull/525) and [iOS](https://github.com/openid/AppAuth-iOS/pull/259). I added the missing invocations of the appropriate methods.

**Note:** on iOS the system alert before logging out still appears. I guess it's something related to `ASWebAuthenticationSession `.

## Steps to verify
- Authenticate using OpenID Connect (`scopes: ['openid']`) and get an idToken;
- Logout passing the idToken and a redirect url;
- Authenticate again, the login form should require to insert username and password again, as the session was properly terminated.
