### PR TITLE
add configurable timeout fn param (connectionTimeoutSeconds/connectionTimeoutMillis)

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -47,7 +47,8 @@ const App = () => {
   React.useEffect(() => {
     prefetchConfiguration({
       warmAndPrefetchChrome: true,
-      ...configs.identityserver
+      connectionTimeoutSeconds: 5,
+      ...configs.identityserver,
     });
   }, []);
 
@@ -55,7 +56,10 @@ const App = () => {
     async provider => {
       try {
         const config = configs[provider];
-        const newAuthState = await authorize(config);
+        const newAuthState = await authorize({
+          ...config,
+          connectionTimeoutSeconds: 5,
+        });
 
         setAuthState({
           hasLoggedInOnce: true,

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ This is the result from the auth server:
 - **scopes** - ([`string`]) the scopes the user has agreed to be granted
 - **authorizationCode** - (`string`) the authorization code (only if `skipCodeExchange=true`)
 - **codeVerifier** - (`string`) the codeVerifier value used for the PKCE exchange (only if both `skipCodeExchange=true` and `usePKCE=true`)
+- **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds.
 
 ### `refresh`
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ This is the result from the auth server:
 - **scopes** - ([`string`]) the scopes the user has agreed to be granted
 - **authorizationCode** - (`string`) the authorization code (only if `skipCodeExchange=true`)
 - **codeVerifier** - (`string`) the codeVerifier value used for the PKCE exchange (only if both `skipCodeExchange=true` and `usePKCE=true`)
-- **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds.
+- **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds. This must be a positive number. The default values are 60 seconds on iOS and 15 seconds on Android.
 
 ### `refresh`
 
@@ -202,12 +202,12 @@ This method will logout a user, as per the [OpenID Connect RP Initiated Logout](
 import { logout } from 'react-native-app-auth';
 
 const config = {
-  issuer: '<YOUR_ISSUER_URL>'
+  issuer: '<YOUR_ISSUER_URL>',
 };
 
 const result = await logout(config, {
   idToken: '<ID_TOKEN>',
-  postLogoutRedirectUrl: '<POST_LOGOUT_URL>'
+  postLogoutRedirectUrl: '<POST_LOGOUT_URL>',
 });
 ```
 
@@ -277,14 +277,14 @@ are not distributed as part of the bridge.
 
 AppAuth supports three options for dependency management.
 
-1. **CocoaPods**
+1.  **CocoaPods**
 
     ```sh
     cd ios
     pod install
     ```
 
-2. **Carthage**
+2.  **Carthage**
 
     With [Carthage](https://github.com/Carthage/Carthage), add the following line to your `Cartfile`:
 
@@ -296,7 +296,7 @@ AppAuth supports three options for dependency management.
 
     Add a copy files build step for `AppAuth.framework`: open Build Phases on Xcode, add a new "Copy Files" phase, choose "Frameworks" as destination, add `AppAuth.framework` and ensure "Code Sign on Copy" is checked.
 
-3. **Static Library**
+3.  **Static Library**
 
     You can also use [AppAuth-iOS](https://github.com/openid/AppAuth-iOS) as a static library. This
     requires linking the library and your project and including the headers. Suggested configuration:

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -95,6 +95,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableMap serviceConfiguration,
             final boolean dangerouslyAllowInsecureHttpRequests,
             final ReadableMap headers,
+            final Double connectionTimeoutMillis,
             final Promise promise
     ) {
         if (warmAndPrefetchChrome) {
@@ -102,7 +103,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         }
 
         this.parseHeaderMap(headers);
-        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders);
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders, connectionTimeoutMillis);
         final CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
 
         if(!isPrefetched) {
@@ -156,12 +157,13 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final String tokenEndpointAuthMethod,
             final ReadableMap additionalParameters,
             final ReadableMap serviceConfiguration,
+            final Double connectionTimeoutMillis,
             final boolean dangerouslyAllowInsecureHttpRequests,
             final ReadableMap headers,
             final Promise promise
     ) {
         this.parseHeaderMap(headers);
-        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.registrationRequestHeaders);
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.registrationRequestHeaders, connectionTimeoutMillis);
         final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
@@ -234,7 +236,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Promise promise
     ) {
         this.parseHeaderMap(headers);
-        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders);
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders, connectionTimeoutMillis);
         final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
@@ -326,7 +328,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Promise promise
     ) {
         this.parseHeaderMap(headers);
-        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders);
+        final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders, connectionTimeoutMillis);
         final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
 
@@ -896,6 +898,27 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         }
 
         CustomConnectionBuilder customConnection = new CustomConnectionBuilder(proxiedBuilder);
+        
+        if (headers != null) {
+            customConnection.setHeaders(headers);
+        }
+
+        customConnection.setConnectionTimeout(connectionTimeoutMillis.intValue());
+
+        return customConnection;
+    }
+
+    private ConnectionBuilder createConnectionBuilder(boolean allowInsecureConnections, Map<String, String> headers) {
+        ConnectionBuilder proxiedBuilder;
+
+        if (allowInsecureConnections) {
+            proxiedBuilder = UnsafeConnectionBuilder.INSTANCE;
+        } else {
+            proxiedBuilder = DefaultConnectionBuilder.INSTANCE;
+        }
+
+        CustomConnectionBuilder customConnection = new CustomConnectionBuilder(proxiedBuilder);
+        
         if (headers != null) {
             customConnection.setHeaders(headers);
         }

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -225,6 +225,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableMap additionalParameters,
             final ReadableMap serviceConfiguration,
             final Boolean skipCodeExchange,
+            final Double connectionTimeoutMillis,
             final Boolean useNonce,
             final Boolean usePKCE,
             final String clientAuthMethod,
@@ -318,6 +319,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableArray scopes,
             final ReadableMap additionalParameters,
             final ReadableMap serviceConfiguration,
+            final Double connectionTimeoutMillis,
             final String clientAuthMethod,
             final boolean dangerouslyAllowInsecureHttpRequests,
             final ReadableMap headers,
@@ -884,7 +886,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
     /*
      *  Create appropriate connection builder based on provided settings
      */
-    private ConnectionBuilder createConnectionBuilder(boolean allowInsecureConnections, Map<String, String> headers) {
+    private ConnectionBuilder createConnectionBuilder(boolean allowInsecureConnections, Map<String, String> headers, Double connectionTimeoutMillis) {
         ConnectionBuilder proxiedBuilder;
 
         if (allowInsecureConnections) {

--- a/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
+++ b/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
@@ -22,6 +22,7 @@ import net.openid.appauth.connectivity.ConnectionBuilder;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.concurrent.TimeUnit;
 import java.util.Map;
 
 
@@ -33,9 +34,9 @@ import java.util.Map;
 public final class CustomConnectionBuilder implements ConnectionBuilder {
 
     private Map<String, String> headers = null;
-    // 0 would be an infinite timeout value - never desirable.
-    // We will only set this value on the connection if it's greater than 0.
-    private int connectionTimeout = 0;
+
+    private int connectionTimeoutMs = (int) TimeUnit.SECONDS.toMillis(15);
+    private int readTimeoutMs = (int) TimeUnit.SECONDS.toMillis(10);     
     private ConnectionBuilder connectionBuilder;
 
     public CustomConnectionBuilder(ConnectionBuilder connectionBuilderToUse) {
@@ -47,7 +48,8 @@ public final class CustomConnectionBuilder implements ConnectionBuilder {
     }
 
     public void setConnectionTimeout (int timeout) {
-        connectionTimeout = timeout;
+        connectionTimeoutMs = timeout;
+        readTimeoutMs = timeout;
     }
 
     @NonNull
@@ -61,10 +63,8 @@ public final class CustomConnectionBuilder implements ConnectionBuilder {
             }
         }
 
-        if (connectionTimeout > 0) {
-            conn.setConnectTimeout(connectionTimeout);
-            conn.setReadTimeout(connectionTimeout);
-        }
+        conn.setConnectTimeout(connectionTimeoutMs);
+        conn.setReadTimeout(readTimeoutMs);
 
         return conn;
     }

--- a/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
+++ b/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
@@ -33,7 +33,7 @@ import java.util.Map;
 public final class CustomConnectionBuilder implements ConnectionBuilder {
 
     private Map<String, String> headers = null;
-    // 0 would be an infinite timeout value - never desireable.
+    // 0 would be an infinite timeout value - never desirable.
     // We will only set this value on the connection if it's greater than 0.
     private int connectionTimeout = 0;
     private ConnectionBuilder connectionBuilder;

--- a/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
+++ b/android/src/main/java/com/rnappauth/utils/CustomConnectionBuilder.java
@@ -33,6 +33,9 @@ import java.util.Map;
 public final class CustomConnectionBuilder implements ConnectionBuilder {
 
     private Map<String, String> headers = null;
+    // 0 would be an infinite timeout value - never desireable.
+    // We will only set this value on the connection if it's greater than 0.
+    private int connectionTimeout = 0;
     private ConnectionBuilder connectionBuilder;
 
     public CustomConnectionBuilder(ConnectionBuilder connectionBuilderToUse) {
@@ -43,14 +46,24 @@ public final class CustomConnectionBuilder implements ConnectionBuilder {
         headers = headersToSet;
     }
 
+    public void setConnectionTimeout (int timeout) {
+        connectionTimeout = timeout;
+    }
+
     @NonNull
     @Override
     public HttpURLConnection openConnection(@NonNull Uri uri) throws IOException {
         HttpURLConnection conn = connectionBuilder.openConnection(uri);
+
         if (headers != null) {
             for (Map.Entry<String, String> header: headers.entrySet()) {
                 conn.setRequestProperty(header.getKey(), header.getValue());
             }
+        }
+
+        if (connectionTimeout > 0) {
+            conn.setConnectTimeout(connectionTimeout);
+            conn.setReadTimeout(connectionTimeout);
         }
 
         return conn;

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,6 +74,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   dangerouslyAllowInsecureHttpRequests?: boolean;
   customHeaders?: CustomHeaders;
   additionalHeaders?: AdditionalHeaders;
+  requestTimeoutSeconds?: number;
   useNonce?: boolean;
   usePKCE?: boolean;
   warmAndPrefetchChrome?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   dangerouslyAllowInsecureHttpRequests?: boolean;
   customHeaders?: CustomHeaders;
   additionalHeaders?: AdditionalHeaders;
-  requestTimeoutSeconds?: number;
+  connectionTimeoutSeconds?: number;
   useNonce?: boolean;
   usePKCE?: boolean;
   warmAndPrefetchChrome?: boolean;

--- a/index.js
+++ b/index.js
@@ -76,18 +76,23 @@ const validateAdditionalHeaders = headers => {
 };
 
 const validateConnectionTimeoutSeconds = timeout => {
-  if (timeout === 0) {
+  if (!timeout) {
     return;
   }
 
   invariant(typeof timeout === 'number', 'Config error: connectionTimeoutSeconds must be a number');
 };
 
-const MILLI_PER_SEC = 1000;
+export const SECOND_IN_MS = 1000;
+export const DEFAULT_TIMEOUT_IOS = 60;
+export const DEFAULT_TIMEOUT_ANDROID = 15;
 
-const convertTimeoutForPlatform = (platform, connectionTimeout) =>
+const convertTimeoutForPlatform = (
+  platform,
+  connectionTimeout = Platform.OS === 'ios' ? DEFAULT_TIMEOUT_IOS : DEFAULT_TIMEOUT_ANDROID
+) =>
   platform === 'android' && connectionTimeout > 0
-    ? connectionTimeout * MILLI_PER_SEC
+    ? connectionTimeout * SECOND_IN_MS
     : connectionTimeout;
 
 export const prefetchConfiguration = async ({
@@ -99,7 +104,7 @@ export const prefetchConfiguration = async ({
   serviceConfiguration,
   dangerouslyAllowInsecureHttpRequests = false,
   customHeaders,
-  connectionTimeoutSeconds = 0,
+  connectionTimeoutSeconds,
 }) => {
   if (Platform.OS === 'android') {
     validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
@@ -136,7 +141,7 @@ export const register = ({
   dangerouslyAllowInsecureHttpRequests = false,
   customHeaders,
   additionalHeaders,
-  connectionTimeoutSeconds = 0,
+  connectionTimeoutSeconds,
 }) => {
   validateIssuerOrServiceConfigurationRegistrationEndpoint(issuer, serviceConfiguration);
   validateHeaders(customHeaders);
@@ -205,7 +210,7 @@ export const authorize = ({
   customHeaders,
   additionalHeaders,
   skipCodeExchange = false,
-  connectionTimeoutSeconds = 0,
+  connectionTimeoutSeconds,
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
@@ -257,7 +262,7 @@ export const refresh = (
     dangerouslyAllowInsecureHttpRequests = false,
     customHeaders,
     additionalHeaders,
-    connectionTimeoutSeconds = 0,
+    connectionTimeoutSeconds,
   },
   { refreshToken }
 ) => {

--- a/index.js
+++ b/index.js
@@ -90,10 +90,7 @@ export const DEFAULT_TIMEOUT_ANDROID = 15;
 const convertTimeoutForPlatform = (
   platform,
   connectionTimeout = Platform.OS === 'ios' ? DEFAULT_TIMEOUT_IOS : DEFAULT_TIMEOUT_ANDROID
-) =>
-  platform === 'android' && connectionTimeout > 0
-    ? connectionTimeout * SECOND_IN_MS
-    : connectionTimeout;
+) => (platform === 'android' ? connectionTimeout * SECOND_IN_MS : connectionTimeout);
 
 export const prefetchConfiguration = async ({
   warmAndPrefetchChrome = false,

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,4 +1,12 @@
-import { authorize, refresh, register, logout } from './';
+import {
+  authorize,
+  refresh,
+  register,
+  logout,
+  DEFAULT_TIMEOUT_IOS,
+  DEFAULT_TIMEOUT_ANDROID,
+  SECOND_IN_MS,
+} from './';
 
 jest.mock('react-native', () => ({
   NativeModules: {
@@ -35,8 +43,7 @@ describe('AppAuth', () => {
   });
 
   const TIMEOUT_SEC = 5;
-  const MILLI_PER_SEC = 1000;
-  const TIMEOUT_MILLIS = TIMEOUT_SEC * MILLI_PER_SEC;
+  const TIMEOUT_MILLIS = TIMEOUT_SEC * SECOND_IN_MS;
 
   const config = {
     issuer: 'test-issuer',
@@ -236,6 +243,24 @@ describe('AppAuth', () => {
             registerConfig.additionalHeaders
           );
         });
+
+        it('calls the native wrapper with the default value when connectionTimeoutSeconds is undefined', () => {
+          // eslint-disable-next-line no-unused-vars
+          const { connectionTimeoutSeconds, ...configValues } = registerConfig;
+          register(configValues);
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            DEFAULT_TIMEOUT_IOS,
+            registerConfig.additionalHeaders
+          );
+        });
       });
 
       describe('additionalHeaders parameter', () => {
@@ -291,6 +316,25 @@ describe('AppAuth', () => {
             registerConfig.additionalParameters,
             registerConfig.serviceConfiguration,
             TIMEOUT_MILLIS,
+            false,
+            registerConfig.customHeaders
+          );
+        });
+
+        it('calls the native wrapper with the default value when connectionTimeoutSeconds is undefined', () => {
+          // eslint-disable-next-line no-unused-vars
+          const { connectionTimeoutSeconds, ...configValues } = registerConfig;
+          register(configValues);
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            DEFAULT_TIMEOUT_ANDROID * SECOND_IN_MS,
             false,
             registerConfig.customHeaders
           );
@@ -511,7 +555,7 @@ describe('AppAuth', () => {
         null,
         null,
         false,
-        0,
+        DEFAULT_TIMEOUT_IOS,
         null,
         true,
         true

--- a/index.spec.js
+++ b/index.spec.js
@@ -34,6 +34,10 @@ describe('AppAuth', () => {
     mockLogout.mockReturnValue('LOGOUT');
   });
 
+  const TIMEOUT_SEC = 5;
+  const MILLI_PER_SEC = 1000;
+  const TIMEOUT_MILLIS = TIMEOUT_SEC * MILLI_PER_SEC;
+
   const config = {
     issuer: 'test-issuer',
     redirectUrl: 'test-redirectUrl',
@@ -47,6 +51,7 @@ describe('AppAuth', () => {
     usePKCE: true,
     customHeaders: null,
     additionalHeaders: { header: 'value' },
+    connectionTimeoutSeconds: TIMEOUT_SEC,
     skipCodeExchange: false,
   };
 
@@ -60,6 +65,7 @@ describe('AppAuth', () => {
     additionalParameters: {},
     additionalHeaders: { header: 'value' },
     serviceConfiguration: null,
+    connectionTimeoutSeconds: TIMEOUT_SEC,
   };
 
   describe('register', () => {
@@ -184,6 +190,15 @@ describe('AppAuth', () => {
       }).toThrow();
     });
 
+    it('throws an error when connectionTimeoutSeconds value isnt a number', () => {
+      expect(() => {
+        register({
+          ...registerConfig,
+          connectionTimeoutSeconds: 'blah',
+        });
+      }).toThrow('Config error: connectionTimeoutSeconds must be a number');
+    });
+
     it('calls the native wrapper with the correct args on iOS', () => {
       register(registerConfig);
       expect(mockRegister).toHaveBeenCalledWith(
@@ -195,6 +210,7 @@ describe('AppAuth', () => {
         registerConfig.tokenEndpointAuthMethod,
         registerConfig.additionalParameters,
         registerConfig.serviceConfiguration,
+        registerConfig.connectionTimeoutSeconds,
         registerConfig.additionalHeaders
       );
     });
@@ -202,6 +218,24 @@ describe('AppAuth', () => {
     describe('iOS-specific', () => {
       beforeEach(() => {
         require('react-native').Platform.OS = 'ios';
+      });
+
+      describe('connectionTimeoutSeconds parameter', () => {
+        it('calls the native wrapper with the non-converted value', () => {
+          register(registerConfig);
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            registerConfig.connectionTimeoutSeconds,
+            registerConfig.additionalHeaders
+          );
+        });
       });
 
       describe('additionalHeaders parameter', () => {
@@ -217,6 +251,7 @@ describe('AppAuth', () => {
             registerConfig.tokenEndpointAuthMethod,
             registerConfig.additionalParameters,
             registerConfig.serviceConfiguration,
+            registerConfig.connectionTimeoutSeconds,
             additionalHeaders
           );
         });
@@ -243,6 +278,25 @@ describe('AppAuth', () => {
         require('react-native').Platform.OS = 'ios';
       });
 
+      describe('connectionTimeoutSeconds parameter', () => {
+        it('calls the native wrapper with the value converted to milliseconds', () => {
+          register(registerConfig);
+          expect(mockRegister).toHaveBeenCalledWith(
+            registerConfig.issuer,
+            registerConfig.redirectUrls,
+            registerConfig.responseTypes,
+            registerConfig.grantTypes,
+            registerConfig.subjectType,
+            registerConfig.tokenEndpointAuthMethod,
+            registerConfig.additionalParameters,
+            registerConfig.serviceConfiguration,
+            TIMEOUT_MILLIS,
+            false,
+            registerConfig.customHeaders
+          );
+        });
+      });
+
       describe('dangerouslyAllowInsecureHttpRequests parameter', () => {
         it('calls the native wrapper with default value `false`', () => {
           register(registerConfig);
@@ -255,6 +309,7 @@ describe('AppAuth', () => {
             registerConfig.tokenEndpointAuthMethod,
             registerConfig.additionalParameters,
             registerConfig.serviceConfiguration,
+            TIMEOUT_MILLIS,
             false,
             registerConfig.customHeaders
           );
@@ -271,6 +326,7 @@ describe('AppAuth', () => {
             registerConfig.tokenEndpointAuthMethod,
             registerConfig.additionalParameters,
             registerConfig.serviceConfiguration,
+            TIMEOUT_MILLIS,
             false,
             registerConfig.customHeaders
           );
@@ -287,6 +343,7 @@ describe('AppAuth', () => {
             registerConfig.tokenEndpointAuthMethod,
             registerConfig.additionalParameters,
             registerConfig.serviceConfiguration,
+            TIMEOUT_MILLIS,
             true,
             registerConfig.customHeaders
           );
@@ -313,6 +370,7 @@ describe('AppAuth', () => {
             registerConfig.tokenEndpointAuthMethod,
             registerConfig.additionalParameters,
             registerConfig.serviceConfiguration,
+            TIMEOUT_MILLIS,
             false,
             customHeaders
           );
@@ -405,6 +463,14 @@ describe('AppAuth', () => {
         });
       }).toThrow();
     });
+    it('throws an error when connectionTimeoutSeconds value isnt a number', () => {
+      expect(() => {
+        authorize({
+          ...config,
+          connectionTimeoutSeconds: 'blah',
+        });
+      }).toThrow('Config error: connectionTimeoutSeconds must be a number');
+    });
 
     it('calls the native wrapper with the correct args on iOS', () => {
       authorize(config);
@@ -417,6 +483,7 @@ describe('AppAuth', () => {
         config.additionalParameters,
         config.serviceConfiguration,
         config.skipCodeExchange,
+        config.connectionTimeoutSeconds,
         config.additionalHeaders,
         config.useNonce,
         config.usePKCE
@@ -444,6 +511,7 @@ describe('AppAuth', () => {
         null,
         null,
         false,
+        0,
         null,
         true,
         true
@@ -453,6 +521,26 @@ describe('AppAuth', () => {
     describe('iOS-specific', () => {
       beforeEach(() => {
         require('react-native').Platform.OS = 'ios';
+      });
+
+      describe('connectionTimeoutSeconds parameter', () => {
+        it('calls the native wrapper with the non-converted value', () => {
+          authorize(config);
+          expect(mockAuthorize).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            config.skipCodeExchange,
+            config.connectionTimeoutSeconds,
+            config.additionalHeaders,
+            config.useNonce,
+            config.usePKCE
+          );
+        });
       });
 
       describe('additionalHeaders parameter', () => {
@@ -468,6 +556,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             config.skipCodeExchange,
+            config.connectionTimeoutSeconds,
             additionalHeaders,
             config.useNonce,
             config.usePKCE
@@ -488,7 +577,7 @@ describe('AppAuth', () => {
 
       describe('useNonce parameter', () => {
         it('calls the native wrapper with default value `true`', () => {
-          authorize(config, { refreshToken: 'such-token' });
+          authorize(config);
           expect(mockAuthorize).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
@@ -498,6 +587,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             false,
+            config.connectionTimeoutSeconds,
             config.additionalHeaders,
             true,
             true
@@ -505,7 +595,7 @@ describe('AppAuth', () => {
         });
 
         it('calls the native wrapper with passed value `false`', () => {
-          authorize({ ...config, useNonce: false }, { refreshToken: 'such-token' });
+          authorize({ ...config, useNonce: false });
           expect(mockAuthorize).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
@@ -515,6 +605,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             false,
+            config.connectionTimeoutSeconds,
             config.additionalHeaders,
             false,
             true
@@ -524,7 +615,7 @@ describe('AppAuth', () => {
 
       describe('usePKCE parameter', () => {
         it('calls the native wrapper with default value `true`', () => {
-          authorize(config, { refreshToken: 'such-token' });
+          authorize(config);
           expect(mockAuthorize).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
@@ -534,6 +625,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             config.skipCodeExchange,
+            config.connectionTimeoutSeconds,
             config.additionalHeaders,
             config.useNonce,
             true
@@ -541,7 +633,7 @@ describe('AppAuth', () => {
         });
 
         it('calls the native wrapper with passed value `false`', () => {
-          authorize({ ...config, usePKCE: false }, { refreshToken: 'such-token' });
+          authorize({ ...config, usePKCE: false });
           expect(mockAuthorize).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
@@ -551,6 +643,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             config.skipCodeExchange,
+            config.connectionTimeoutSeconds,
             config.additionalHeaders,
             config.useNonce,
             false
@@ -564,9 +657,28 @@ describe('AppAuth', () => {
         require('react-native').Platform.OS = 'android';
       });
 
-      afterEach(() => {
-        require('react-native').Platform.OS = 'ios';
+      describe('connectionTimeoutSeconds parameter', () => {
+        it('calls the native wrapper with the value converted to milliseconds', () => {
+          authorize(config);
+          expect(mockAuthorize).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            config.skipCodeExchange,
+            TIMEOUT_MILLIS,
+            config.useNonce,
+            config.usePKCE,
+            config.clientAuthMethod,
+            false,
+            config.customHeaders
+          );
+        });
       });
+
       describe('dangerouslyAllowInsecureHttpRequests parameter', () => {
         it('calls the native wrapper with default value `false`', () => {
           authorize(config);
@@ -579,6 +691,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             config.skipCodeExchange,
+            TIMEOUT_MILLIS,
             config.useNonce,
             config.usePKCE,
             config.clientAuthMethod,
@@ -598,6 +711,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             false,
+            TIMEOUT_MILLIS,
             config.useNonce,
             config.usePKCE,
             config.clientAuthMethod,
@@ -617,6 +731,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             false,
+            TIMEOUT_MILLIS,
             config.useNonce,
             config.usePKCE,
             config.clientAuthMethod,
@@ -645,6 +760,7 @@ describe('AppAuth', () => {
             config.additionalParameters,
             config.serviceConfiguration,
             false,
+            TIMEOUT_MILLIS,
             config.useNonce,
             config.usePKCE,
             config.clientAuthMethod,
@@ -662,33 +778,39 @@ describe('AppAuth', () => {
       mockAuthorize.mockReset();
       mockRefresh.mockReset();
       mockLogout.mockReset();
+      require('react-native').Platform.OS = 'ios';
     });
+
+    const refreshToken = 'abc-token';
 
     it('throws an error when issuer is not a string and serviceConfiguration is not passed', () => {
       expect(() => {
-        authorize({ ...config, issuer: () => ({}) });
+        refresh({ ...config, issuer: () => ({}) }, { refreshToken });
       }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when serviceConfiguration does not have tokenEndpoint and issuer is not passed', () => {
       expect(() => {
-        authorize({
-          ...config,
-          issuer: undefined,
-          serviceConfiguration: { authorizationEndpoint: '' },
-        });
+        refresh(
+          {
+            ...config,
+            issuer: undefined,
+            serviceConfiguration: { authorizationEndpoint: '' },
+          },
+          { refreshToken }
+        );
       }).toThrow('Config error: you must provide either an issuer or a service endpoints');
     });
 
     it('throws an error when redirectUrl is not a string', () => {
       expect(() => {
-        authorize({ ...config, redirectUrl: {} });
+        refresh({ ...config, redirectUrl: {} }, { refreshToken });
       }).toThrow('Config error: redirectUrl must be a string');
     });
 
     it('throws an error when clientId is not a string', () => {
       expect(() => {
-        authorize({ ...config, clientId: 123 });
+        refresh({ ...config, clientId: 123 }, { refreshToken });
       }).toThrow('Config error: clientId must be a string');
     });
 
@@ -697,18 +819,30 @@ describe('AppAuth', () => {
         refresh(config, {});
       }).toThrow('Please pass in a refresh token');
     });
+    it('throws an error when connectionTimeoutSeconds value isnt a number', () => {
+      expect(() => {
+        refresh(
+          {
+            ...config,
+            connectionTimeoutSeconds: 'blah',
+          },
+          { refreshToken }
+        );
+      }).toThrow('Config error: connectionTimeoutSeconds must be a number');
+    });
 
     it('calls the native wrapper with the correct args on iOS', () => {
-      refresh({ ...config }, { refreshToken: 'such-token' });
+      refresh({ ...config }, { refreshToken });
       expect(mockRefresh).toHaveBeenCalledWith(
         config.issuer,
         config.redirectUrl,
         config.clientId,
         config.clientSecret,
-        'such-token',
+        refreshToken,
         config.scopes,
         config.additionalParameters,
         config.serviceConfiguration,
+        config.connectionTimeoutSeconds,
         config.additionalHeaders
       );
     });
@@ -718,10 +852,27 @@ describe('AppAuth', () => {
         require('react-native').Platform.OS = 'ios';
       });
 
+      describe('connectionTimeoutSeconds parameter', () => {
+        it('calls the native wrapper with the non-converted value', () => {
+          refresh(config, { refreshToken });
+          expect(mockRefresh).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            refreshToken,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            config.connectionTimeoutSeconds,
+            config.additionalHeaders
+          );
+        });
+      });
+
       describe('additionalHeaders parameter', () => {
         it('calls the native wrapper with additional headers', () => {
           const additionalHeaders = { header: 'value' };
-          const refreshToken = 'a-token';
           refresh({ ...config, additionalHeaders }, { refreshToken });
           expect(mockRefresh).toHaveBeenCalledWith(
             config.issuer,
@@ -732,16 +883,14 @@ describe('AppAuth', () => {
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            config.connectionTimeoutSeconds,
             additionalHeaders
           );
         });
 
         it('throws an error when values are not Record<string,string>', () => {
           expect(() => {
-            refresh(
-              { ...config, additionalHeaders: { notString: {} } },
-              { refreshToken: 'such-token' }
-            );
+            refresh({ ...config, additionalHeaders: { notString: {} } }, { refreshToken });
           }).toThrow();
         });
       });
@@ -752,22 +901,39 @@ describe('AppAuth', () => {
         require('react-native').Platform.OS = 'android';
       });
 
-      afterEach(() => {
-        require('react-native').Platform.OS = 'ios';
-      });
-
-      describe(' dangerouslyAllowInsecureHttpRequests parameter', () => {
-        it('calls the native wrapper with default value `false`', () => {
-          refresh(config, { refreshToken: 'such-token' });
+      describe('connectionTimeoutSeconds parameter', () => {
+        it('calls the native wrapper with the value converted to milliseconds', () => {
+          refresh(config, { refreshToken });
           expect(mockRefresh).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
             config.clientId,
             config.clientSecret,
-            'such-token',
+            refreshToken,
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            TIMEOUT_MILLIS,
+            config.clientAuthMethod,
+            false,
+            config.customHeaders
+          );
+        });
+      });
+
+      describe(' dangerouslyAllowInsecureHttpRequests parameter', () => {
+        it('calls the native wrapper with default value `false`', () => {
+          refresh(config, { refreshToken });
+          expect(mockRefresh).toHaveBeenCalledWith(
+            config.issuer,
+            config.redirectUrl,
+            config.clientId,
+            config.clientSecret,
+            refreshToken,
+            config.scopes,
+            config.additionalParameters,
+            config.serviceConfiguration,
+            TIMEOUT_MILLIS,
             config.clientAuthMethod,
             false,
             config.customHeaders
@@ -775,19 +941,17 @@ describe('AppAuth', () => {
         });
 
         it('calls the native wrapper with passed value `false`', () => {
-          refresh(
-            { ...config, dangerouslyAllowInsecureHttpRequests: false },
-            { refreshToken: 'such-token' }
-          );
+          refresh({ ...config, dangerouslyAllowInsecureHttpRequests: false }, { refreshToken });
           expect(mockRefresh).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
             config.clientId,
             config.clientSecret,
-            'such-token',
+            refreshToken,
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            TIMEOUT_MILLIS,
             config.clientAuthMethod,
             false,
             config.customHeaders
@@ -795,19 +959,17 @@ describe('AppAuth', () => {
         });
 
         it('calls the native wrapper with passed value `true`', () => {
-          refresh(
-            { ...config, dangerouslyAllowInsecureHttpRequests: true },
-            { refreshToken: 'such-token' }
-          );
+          refresh({ ...config, dangerouslyAllowInsecureHttpRequests: true }, { refreshToken });
           expect(mockRefresh).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
             config.clientId,
             config.clientSecret,
-            'such-token',
+            refreshToken,
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
+            TIMEOUT_MILLIS,
             config.clientAuthMethod,
             true,
             config.customHeaders
@@ -820,18 +982,17 @@ describe('AppAuth', () => {
           const customTokenHeaders = { Authorization: 'Basic someBase64Value' };
           const customAuthorizeHeaders = { Authorization: 'Basic someOtherBase64Value' };
           const customHeaders = { token: customTokenHeaders, authorize: customAuthorizeHeaders };
-          authorize({ ...config, customHeaders });
-          expect(mockAuthorize).toHaveBeenCalledWith(
+          refresh({ ...config, customHeaders }, { refreshToken });
+          expect(mockRefresh).toHaveBeenCalledWith(
             config.issuer,
             config.redirectUrl,
             config.clientId,
             config.clientSecret,
+            refreshToken,
             config.scopes,
             config.additionalParameters,
             config.serviceConfiguration,
-            false,
-            config.useNonce,
-            config.usePKCE,
+            TIMEOUT_MILLIS,
             config.clientAuthMethod,
             false,
             customHeaders

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -44,12 +44,13 @@ RCT_REMAP_METHOD(register,
                  subjectType: (NSString *) subjectType
                  tokenEndpointAuthMethod: (NSString *) tokenEndpointAuthMethod
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
+                 connectionTimeoutSeconds: (double) connectionTimeoutSeconds
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
-    [self configureUrlSession:additionalHeaders];
+    [self configureUrlSession:additionalHeaders sessionTimeout:connectionTimeoutSeconds];
 
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
@@ -92,13 +93,14 @@ RCT_REMAP_METHOD(authorize,
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  skipCodeExchange: (BOOL) skipCodeExchange
+                 connectionTimeoutSeconds: (double) connectionTimeoutSeconds
                  additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  useNonce: (BOOL *) useNonce
                  usePKCE: (BOOL *) usePKCE
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
-    [self configureUrlSession:additionalHeaders];
+    [self configureUrlSession:additionalHeaders sessionTimeout:connectionTimeoutSeconds];
 
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
@@ -145,11 +147,12 @@ RCT_REMAP_METHOD(refresh,
                  scopes: (NSArray *) scopes
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
+                 connectionTimeoutSeconds: (double) connectionTimeoutSeconds
                  additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  resolve:(RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
-    [self configureUrlSession:additionalHeaders];
+    [self configureUrlSession:additionalHeaders sessionTimeout:connectionTimeoutSeconds];
 
     // if we have manually provided configuration, we can use it and skip the OIDC well-known discovery endpoint call
     if (serviceConfiguration) {
@@ -465,10 +468,14 @@ RCT_REMAP_METHOD(logout,
                                                         }];
 }
 
-- (void) configureUrlSession: (NSDictionary*) headers {
+- (void)configureUrlSession: (NSDictionary*) headers sessionTimeout: (double) sessionTimeout{
     NSURLSessionConfiguration* configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
     if (headers != nil) {
         configuration.HTTPAdditionalHeaders = headers;
+    }
+
+    if (sessionTimeout > 0) {
+      configuration.timeoutIntervalForRequest = sessionTimeout;
     }
 
     NSURLSession* session = [NSURLSession sessionWithConfiguration:configuration];

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -474,9 +474,7 @@ RCT_REMAP_METHOD(logout,
         configuration.HTTPAdditionalHeaders = headers;
     }
 
-    if (sessionTimeout > 0) {
-      configuration.timeoutIntervalForRequest = sessionTimeout;
-    }
+    configuration.timeoutIntervalForRequest = sessionTimeout;
 
     NSURLSession* session = [NSURLSession sessionWithConfiguration:configuration];
     [OIDURLSessionProvider setSession:session];


### PR DESCRIPTION
Fixes #236 #479

## Description

- adds a connectionTimeoutSeconds fn param to prefetchConfiguration, authorize and refresh
- adds connectionTimeoutSeconds property to AuthConfiguration type
- adds connectionTimeoutSeconds param validation and test cases
- converts value to milliseconds for Android platform
- adds logic to native methods to handle new fn param
- adds android specific test cases for time conversion (seconds -> milliseconds)

Random addition
- adds default value for `warmAndPrefetchChrome` fn param (fixes 479)

## Steps to verify

(not sure if this is the best way to go about it 🤷‍♂️ )

1. Manually sync the Example/node_modules/react-native-app-auth directory with the updated ios/android dirs, react-native-app-auth.podspec and index.js files.

`cp -r ios Example/node_modules/react-native-app-auth && cp -r android Example/node_modules/react-native-app-auth && cp index.js Example/node_modules/react-native-app-auth && cp react-native-app-auth.podspec Example/node_modules/react-native-app-auth`

2. change the `issuer` property of the identityserver config in Example/App.js to a url that will never resolve (ex. http://www.example:81.com)

3. If the url doesn't use https protocol, add `dangerouslyAllowInsecureHttpRequests: true`  to the argument object passed to the 'authorize' method in Example/App.js.

4. Run the Example app and attempt to authorize through identity server. The default timeout is 60 seconds for iOS and 15 seconds for Android. It should be apparent that the configured timeout of 5 seconds is being respected.