### PR TITLE
dep(android): update net.openid:appauth from 0.8.1 to 0.11.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,5 +57,5 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation 'net.openid:appauth:0.11.1'
-    implementation 'androidx.browser:browser:1.2.0'
+    implementation 'androidx.browser:browser:1.4.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,6 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'net.openid:appauth:0.8.1'
+    implementation 'net.openid:appauth:0.11.1'
     implementation 'androidx.browser:browser:1.2.0'
 }

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -784,11 +784,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
         final Activity currentActivity = getCurrentActivity();
 
         EndSessionRequest.Builder endSessionRequestBuilder =
-                new EndSessionRequest.Builder(
-                        serviceConfiguration,
-                        idTokenHint,
-                        Uri.parse(postLogoutRedirectUri)
-                );
+                new EndSessionRequest.Builder(serviceConfiguration)
+                        .setIdTokenHint(idTokenHint)
+                        .setPostLogoutRedirectUri(Uri.parse(postLogoutRedirectUri));
 
         if (additionalParametersMap != null) {
             if (additionalParametersMap.containsKey("state")) {

--- a/android/src/main/java/com/rnappauth/utils/EndSessionResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/EndSessionResponseFactory.java
@@ -14,7 +14,9 @@ public final class EndSessionResponseFactory {
 
         map.putString("state", response.state);
         map.putString("idTokenHint", response.request.idTokenHint);
-        map.putString("postLogoutRedirectUri", response.request.postLogoutRedirectUri.toString());
+        if (response.request.postLogoutRedirectUri != null) {
+            map.putString("postLogoutRedirectUri", response.request.postLogoutRedirectUri.toString());
+        }
 
         return map;
     }

--- a/android/src/main/java/com/rnappauth/utils/EndSessionResponseFactory.java
+++ b/android/src/main/java/com/rnappauth/utils/EndSessionResponseFactory.java
@@ -13,8 +13,8 @@ public final class EndSessionResponseFactory {
         WritableMap map = Arguments.createMap();
 
         map.putString("state", response.state);
-        map.putString("idTokenHint", response.request.idToken);
-        map.putString("postLogoutRedirectUri", response.request.redirectUri.toString());
+        map.putString("idTokenHint", response.request.idTokenHint);
+        map.putString("postLogoutRedirectUri", response.request.postLogoutRedirectUri.toString());
 
         return map;
     }


### PR DESCRIPTION
Fixes when targeting Android SDK 31 (Android 12), it's not possible to login via browser, on Android 7, 8, 9, 10 or 11 when you have Opera or Opera Beta installed.
Authorising immediately fails with an error (code: no_browser_found, message: Error not specified).

## Description

Bumps the net.openid:appauth library from 0.8.1 to 0.11.1 (https://github.com/openid/AppAuth-Android/tags).

## Steps to verify

1. Use targetSdk 31 to build for Android 12
2. Install Opera or Opera beta on a phone with Android 7, 8, 9, 10 or 11
3. Launch webbrowser for login by calling `authorize`
4. Promise is rejected and the web browser never launches
