### PR TITLE
fix: generate state if no state is passed ios

### DIFF
--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -329,7 +329,7 @@ RCT_REMAP_METHOD(logout,
                                                      scope:[OIDScopeUtilities scopesWithArray:scopes]
                                                redirectURL:[NSURL URLWithString:redirectUrl]
                                               responseType:OIDResponseTypeCode
-                                                     state:[[self class] generateState]
+                                                     state: additionalParameters[@"state"] ? nil : [[self class] generateState]
                                                      nonce:nonce
                                               codeVerifier:codeVerifier
                                              codeChallenge:codeChallenge


### PR DESCRIPTION
Fixes #... <!-- Link the issue that will be fixed by merging this PR, e.g. Fixes #1234 -->
https://github.com/FormidableLabs/react-native-app-auth/issues/559
https://github.com/FormidableLabs/react-native-app-auth/issues/703

## Description

<!-- Include a summary of the work -->

## Steps to verify

Pass state into additionalParameters
Check for state in redirect

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
