### PR TITLE
Custom Nonce passing as an additional parameter is not properly configured

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,6 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'net.openid:appauth:0.9.1'
+    implementation 'net.openid:appauth:0.11.1'
     implementation 'androidx.browser:browser:1.4.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,6 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'net.openid:appauth:0.11.1'
+    implementation 'net.openid:appauth:0.9.1'
     implementation 'androidx.browser:browser:1.4.0'
 }

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -674,6 +674,9 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 authRequestBuilder.setState(additionalParametersMap.get("state"));
                 additionalParametersMap.remove("state");
             }
+               if (additionalParametersMap.containsKey("nonce")) {
+                authRequestBuilder.setNonce(additionalParametersMap.get("nonce"));
+            }
 
             authRequestBuilder.setAdditionalParameters(additionalParametersMap);
         }

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -677,6 +677,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
             if (additionalParametersMap.containsKey("nonce")) {
                 authRequestBuilder.setNonce(additionalParametersMap.get("nonce"));
+                additionalParametersMap.remove("nonce");
             
            }
             if (additionalParametersMap.containsKey("ui_locales")) {

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -319,7 +319,7 @@ RCT_REMAP_METHOD(logout,
 
     NSString *codeVerifier = usePKCE ? [[self class] generateCodeVerifier] : nil;
     NSString *codeChallenge = usePKCE ? [[self class] codeChallengeS256ForVerifier:codeVerifier] : nil;
-    NSString *nonce = useNonce ? [[self class] generateState] : nil;
+    NSString *nonce =  useNonce ? additionalParameters[@"nonce"]? additionalParameters[@"nonce"]:  [[self class] generateState] : nil ;
 
     // builds authentication request
     OIDAuthorizationRequest *request =


### PR DESCRIPTION

## Description

The nonce is not setup correctly once it's passed from JS to the native side as an additional parameter , resulting in a nonce comparison error.

When the nonce is passed as a parameter in the additional parameters section , and setting UseNonce to true , the native side does not take in consideration those changes and keeps the randomly generated nonce instead for comparison.

This PR helps checking if there is a nonce being passed in the additional parameters section and changes it if there is.


