### PR TITLE
Pass additional param ui_locales

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -674,6 +674,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 authRequestBuilder.setState(additionalParametersMap.get("state"));
                 additionalParametersMap.remove("state");
             }
+            if (additionalParametersMap.containsKey("ui_locales")) {
+                authRequestBuilder.setUiLocales(additionalParametersMap.get("ui_locales"));
+                additionalParametersMap.remove("ui_locales");
+            }
 
             authRequestBuilder.setAdditionalParameters(additionalParametersMap);
         }


### PR DESCRIPTION
Fixes #730 - error "Parameter ui_locales is directly supported via the authorization request builder, use the builder method instead" when using ui_locales as additional parameter on Android.

## Description

Uses setUiLocales builder method when ui_locales was given with additional parameters.

## Steps to verify

1. Add ui_locales to additionalParameters in AuthConfiguration
2. Launch webbrowser for login by calling authorize
3. Error is thrown and the web browser never launches