### PR TITLE
Make the PodSpec Dependency not locked to 1.4.0 and use ~> '1.4'

### DIFF
--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'React-Core'
-  s.dependency 'AppAuth', '1.4.0'
+  s.dependency 'AppAuth', '~> 1.4'
 end


### PR DESCRIPTION
Fixes #755 

## Description
Changes the PodSpec dependency for App Auth to use the optimistic operator to use the next minor version instead of being locked to 1.4.0

<!-- Include a summary of the work -->

## Steps to verify

<!-- Describe steps to verify -->

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
