### PR TITLE
Fix #734 customHeaders is not taken into account

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -94,7 +94,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableArray scopes,
             final ReadableMap serviceConfiguration,
             final boolean dangerouslyAllowInsecureHttpRequests,
-            final ReadableMap headers,
+            final ReadableMap customHeaders,
             final Double connectionTimeoutMillis,
             final Promise promise
     ) {
@@ -102,7 +102,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             warmChromeCustomTab(reactContext, issuer);
         }
 
-        this.parseHeaderMap(headers);
+        this.parseHeaderMap(customHeaders);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders, connectionTimeoutMillis);
         final CountDownLatch fetchConfigurationLatch = new CountDownLatch(1);
 
@@ -159,10 +159,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableMap serviceConfiguration,
             final Double connectionTimeoutMillis,
             final boolean dangerouslyAllowInsecureHttpRequests,
-            final ReadableMap headers,
+            final ReadableMap customHeaders,
             final Promise promise
     ) {
-        this.parseHeaderMap(headers);
+        this.parseHeaderMap(customHeaders);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.registrationRequestHeaders, connectionTimeoutMillis);
         final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
@@ -232,10 +232,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Boolean usePKCE,
             final String clientAuthMethod,
             final boolean dangerouslyAllowInsecureHttpRequests,
-            final ReadableMap headers,
+            final ReadableMap customHeaders,
             final Promise promise
     ) {
-        this.parseHeaderMap(headers);
+        this.parseHeaderMap(customHeaders);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.authorizationRequestHeaders, connectionTimeoutMillis);
         final AppAuthConfiguration appAuthConfiguration = this.createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);
@@ -324,10 +324,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Double connectionTimeoutMillis,
             final String clientAuthMethod,
             final boolean dangerouslyAllowInsecureHttpRequests,
-            final ReadableMap headers,
+            final ReadableMap customHeaders,
             final Promise promise
     ) {
-        this.parseHeaderMap(headers);
+        this.parseHeaderMap(customHeaders);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests, this.tokenRequestHeaders, connectionTimeoutMillis);
         final AppAuthConfiguration appAuthConfiguration = createAppAuthConfiguration(builder, dangerouslyAllowInsecureHttpRequests);
         final HashMap<String, String> additionalParametersMap = MapUtil.readableMapToHashMap(additionalParameters);


### PR DESCRIPTION
Fixes #734

## Description
As per the documentation android custom Headers should pass as `customHeaders` but in module it was accessed as `headers`

https://github.com/FormidableLabs/react-native-app-auth#config

- **customHeaders** - (`object`) _ANDROID_ you can specify custom headers to pass during authorize request and/or token request.
  - **authorize** - (`{ [key: string]: value }`) headers to be passed during authorization request.
  - **token** - (`{ [key: string]: value }`) headers to be passed during token retrieval request.
  - **register** - (`{ [key: string]: value }`) headers to be passed during registration request.

## Steps to verify

Could verify by passing customHeaders in android build

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
