### PR TITLE
chore: update example app to new identity server

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -18,16 +18,16 @@ import {
 
 const configs = {
   identityserver: {
-    issuer: 'https://demo.identityserver.io',
+    issuer: 'https://demo.duendesoftware.com',
     clientId: 'interactive.public',
     redirectUrl: 'io.identityserver.demo:/oauthredirect',
     additionalParameters: {},
     scopes: ['openid', 'profile', 'email', 'offline_access'],
 
     // serviceConfiguration: {
-    //   authorizationEndpoint: 'https://demo.identityserver.io/connect/authorize',
-    //   tokenEndpoint: 'https://demo.identityserver.io/connect/token',
-    //   revocationEndpoint: 'https://demo.identityserver.io/connect/revoke'
+    //   authorizationEndpoint: 'https://demo.duendesoftware.com/connect/authorize',
+    //   tokenEndpoint: 'https://demo.duendesoftware.com/connect/token',
+    //   revocationEndpoint: 'https://demo.duendesoftware.com/connect/revoke'
     // }
   },
   auth0: {

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -1,9 +1,10 @@
 PODS:
-  - AppAuth (1.4.0):
-    - AppAuth/Core (= 1.4.0)
-    - AppAuth/ExternalUserAgent (= 1.4.0)
-  - AppAuth/Core (1.4.0)
-  - AppAuth/ExternalUserAgent (1.4.0)
+  - AppAuth (1.6.0):
+    - AppAuth/Core (= 1.6.0)
+    - AppAuth/ExternalUserAgent (= 1.6.0)
+  - AppAuth/Core (1.6.0)
+  - AppAuth/ExternalUserAgent (1.6.0):
+    - AppAuth/Core
   - boost-for-react-native (1.63.0)
   - DoubleConversion (1.1.6)
   - FBLazyVector (0.63.2)
@@ -190,9 +191,9 @@ PODS:
     - React-cxxreact (= 0.63.2)
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
-  - react-native-app-auth (6.0.0):
-    - AppAuth (= 1.4.0)
-    - React
+  - react-native-app-auth (6.4.3):
+    - AppAuth (~> 1.4)
+    - React-Core
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
   - React-RCTAnimation (0.63.2):
@@ -273,7 +274,7 @@ DEPENDENCIES:
   - React-jsi (from `../node_modules/react-native/ReactCommon/jsi`)
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
-  - react-native-app-auth (from `../node_modules/react-native-app-auth`)
+  - react-native-app-auth (from `../..`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
   - React-RCTAnimation (from `../node_modules/react-native/Libraries/NativeAnimation`)
   - React-RCTBlob (from `../node_modules/react-native/Libraries/Blob`)
@@ -323,7 +324,7 @@ EXTERNAL SOURCES:
   React-jsinspector:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   react-native-app-auth:
-    :path: "../node_modules/react-native-app-auth"
+    :path: "../.."
   React-RCTActionSheet:
     :path: "../node_modules/react-native/Libraries/ActionSheetIOS"
   React-RCTAnimation:
@@ -348,7 +349,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
+  AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   DoubleConversion: cde416483dac037923206447da6e1454df403714
   FBLazyVector: 3ef4a7f62e7db01092f9d517d2ebc0d0677c4a37
@@ -365,7 +366,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-app-auth: 6ca234b90aa54adb133ad70261b0324fdc668151
+  react-native-app-auth: e5b48009fda193a6a6808ec8f3d2cf159d9cbba4
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13
@@ -380,4 +381,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 949ad8df05a48859791386bfa525887dad48241b
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.3


### PR DESCRIPTION
## Description

The demo app was pointing to an old identity server url: https://demo.identityserver.io/
This has since been moved to https://demo.duendesoftware.com/

Source: https://github.com/IdentityServer/IdentityServer4/issues/5480

## Steps to verify

Run the example app & log in with Identity Server.