### PR TITLE
Add support for prefersEphemeralSession on iOS. Refs #771

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -71,6 +71,7 @@ const App = () => {
         const newAuthState = await authorize({
           ...config,
           connectionTimeoutSeconds: 5,
+          iosPrefersEphemeralSession: true
         });
 
         setAuthState({

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -192,7 +192,7 @@ PODS:
     - React-jsi (= 0.63.2)
   - React-jsinspector (0.63.2)
   - react-native-app-auth (6.4.3):
-    - AppAuth (~> 1.4)
+    - AppAuth (~> 1.6)
     - React-Core
   - React-RCTActionSheet (0.63.2):
     - React-Core/RCTActionSheetHeaders (= 0.63.2)
@@ -366,7 +366,7 @@ SPEC CHECKSUMS:
   React-jsi: 54245e1d5f4b690dec614a73a3795964eeef13a8
   React-jsiexecutor: 8ca588cc921e70590820ce72b8789b02c67cce38
   React-jsinspector: b14e62ebe7a66e9231e9581279909f2fc3db6606
-  react-native-app-auth: e5b48009fda193a6a6808ec8f3d2cf159d9cbba4
+  react-native-app-auth: 0aaa426c98f354afa487f1d792bd711d83495a22
   React-RCTActionSheet: 910163b6b09685a35c4ebbc52b66d1bfbbe39fc5
   React-RCTAnimation: 9a883bbe1e9d2e158d4fb53765ed64c8dc2200c6
   React-RCTBlob: 39cf0ece1927996c4466510e25d2105f67010e13

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ with optional overrides.
 - **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)
 - **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `SFAuthenticationSession` or `SFSafariViewController` are used.
+- **iosPrefersEphemeralSession** - (`boolean`) (default: `false`) _IOS_ indicates whether the session should ask the browser for a private authentication session.
 - **androidAllowCustomBrowsers** - (`string[]`) (default: undefined) _ANDROID_ override the used browser for authorization. If no value is provided, all browsers are allowed.
 - **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds. This must be a positive number. The default values are 60 seconds on iOS and 15 seconds on Android.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,12 +80,21 @@ export type AuthConfiguration = BaseAuthConfiguration & {
   warmAndPrefetchChrome?: boolean;
   skipCodeExchange?: boolean;
   iosCustomBrowser?: 'safari' | 'chrome' | 'opera' | 'firefox';
-  androidAllowCustomBrowsers?: ('chrome' | 'chromeCustomTab' | 'firefox' | 'firefoxCustomTab' | 'samsung' | 'samsungCustomTab')[]
+  androidAllowCustomBrowsers?: (
+    | 'chrome'
+    | 'chromeCustomTab'
+    | 'firefox'
+    | 'firefoxCustomTab'
+    | 'samsung'
+    | 'samsungCustomTab'
+  )[];
+  iosPrefersEphemeralSession?: boolean;
 };
 
 export type EndSessionConfiguration = BaseAuthConfiguration & {
   additionalParameters?: { [name: string]: string };
   dangerouslyAllowInsecureHttpRequests?: boolean;
+  iosPrefersEphemeralSession?: boolean;
 };
 
 export interface AuthorizeResult {

--- a/index.js
+++ b/index.js
@@ -210,6 +210,7 @@ export const authorize = ({
   iosCustomBrowser = null,
   androidAllowCustomBrowsers = null,
   connectionTimeoutSeconds,
+  iosPrefersEphemeralSession = false,
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
@@ -245,6 +246,7 @@ export const authorize = ({
     nativeMethodArguments.push(useNonce);
     nativeMethodArguments.push(usePKCE);
     nativeMethodArguments.push(iosCustomBrowser);
+    nativeMethodArguments.push(iosPrefersEphemeralSession);
   }
 
   return RNAppAuth.authorize(...nativeMethodArguments);
@@ -356,6 +358,7 @@ export const logout = (
     additionalParameters,
     dangerouslyAllowInsecureHttpRequests = false,
     iosCustomBrowser = null,
+    iosPrefersEphemeralSession = false,
     androidAllowCustomBrowsers = null,
   },
   { idToken, postLogoutRedirectUrl }
@@ -379,6 +382,7 @@ export const logout = (
 
   if (Platform.OS === 'ios') {
     nativeMethodArguments.push(iosCustomBrowser);
+    nativeMethodArguments.push(iosPrefersEphemeralSession);
   }
 
   return RNAppAuth.logout(...nativeMethodArguments);

--- a/index.spec.js
+++ b/index.spec.js
@@ -61,6 +61,7 @@ describe('AppAuth', () => {
     connectionTimeoutSeconds: TIMEOUT_SEC,
     skipCodeExchange: false,
     iosCustomBrowser: 'safari',
+    iosPrefersEphemeralSession: true,
     androidAllowCustomBrowsers: ['chrome'],
   };
 
@@ -533,7 +534,8 @@ describe('AppAuth', () => {
         config.additionalHeaders,
         config.useNonce,
         config.usePKCE,
-        config.iosCustomBrowser
+        config.iosCustomBrowser,
+        config.iosPrefersEphemeralSession
       );
     });
 
@@ -562,7 +564,8 @@ describe('AppAuth', () => {
         null,
         true,
         true,
-        null
+        null,
+        false
       );
     });
 
@@ -587,7 +590,8 @@ describe('AppAuth', () => {
             config.additionalHeaders,
             config.useNonce,
             config.usePKCE,
-            config.iosCustomBrowser
+            config.iosCustomBrowser,
+            config.iosPrefersEphemeralSession
           );
         });
       });
@@ -609,7 +613,8 @@ describe('AppAuth', () => {
             additionalHeaders,
             config.useNonce,
             config.usePKCE,
-            config.iosCustomBrowser
+            config.iosCustomBrowser,
+            config.iosPrefersEphemeralSession
           );
         });
 
@@ -641,7 +646,8 @@ describe('AppAuth', () => {
             config.additionalHeaders,
             true,
             true,
-            config.iosCustomBrowser
+            config.iosCustomBrowser,
+            config.iosPrefersEphemeralSession
           );
         });
 
@@ -660,7 +666,8 @@ describe('AppAuth', () => {
             config.additionalHeaders,
             false,
             true,
-            config.iosCustomBrowser
+            config.iosCustomBrowser,
+            config.iosPrefersEphemeralSession
           );
         });
       });
@@ -681,7 +688,8 @@ describe('AppAuth', () => {
             config.additionalHeaders,
             config.useNonce,
             true,
-            config.iosCustomBrowser
+            config.iosCustomBrowser,
+            config.iosPrefersEphemeralSession
           );
         });
 
@@ -700,7 +708,8 @@ describe('AppAuth', () => {
             config.additionalHeaders,
             config.useNonce,
             false,
-            config.iosCustomBrowser
+            config.iosCustomBrowser,
+            config.iosPrefersEphemeralSession
           );
         });
       });
@@ -1120,7 +1129,8 @@ describe('AppAuth', () => {
           '_redirect_',
           config.serviceConfiguration,
           config.additionalParameters,
-          config.iosCustomBrowser
+          config.iosCustomBrowser,
+          config.iosPrefersEphemeralSession
         );
       });
     });

--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'React-Core'
-  s.dependency 'AppAuth', '~> 1.4'
+  s.dependency 'AppAuth', '~> 1.6'
 end


### PR DESCRIPTION
Fixes #771
Refs #723

## Description

- Upgrade `AppAuth` to 1.6
- Add support for `prefersEphemeralSession` for `authorize()` and `logout()`

When setting the `iosPrefersEphemeralSession` option to true, we no longer receive the "Sign in" popup on ios.

## Steps to verify

1. `cd Example`
2. Start metro bundler: `npm start`
3. Open in ios: `npm run ios`
4. Open `./App.js` and set `iosPrefersEphemeralSession: false` when calling `authorize()`
5. Click "Authorize Auth0"
6. Note you get a popup saying "Example wants to use auth0.com to Sign in"
7. Open `./App.js` and set `iosPrefersEphemeralSession: true` when calling `authorize()` 
8. Reload app
9. Click "Authorize Auth0"
10. Note you don't get any popup

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->

## TODO

- [x] Update README
- [x] Rename from `prefersEphemeralSession` to `iosPrefersEphemeralSession`
