### PR TITLE
Fix #790 order of parameters for `register` on iOS

### DIFF
--- a/.changeset/curly-years-obey.md
+++ b/.changeset/curly-years-obey.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+Fix order of parameters for register on iOS

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -46,8 +46,8 @@ RCT_REMAP_METHOD(register,
                  subjectType: (NSString *) subjectType
                  tokenEndpointAuthMethod: (NSString *) tokenEndpointAuthMethod
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
-                 connectionTimeoutSeconds: (double) connectionTimeoutSeconds
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
+                 connectionTimeoutSeconds: (double) connectionTimeoutSeconds
                  additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)


### PR DESCRIPTION
Fixes [#790 IOS Register method ::: Argument 7 (double) of RNAppAuth.register must not be null](https://github.com/FormidableLabs/react-native-app-auth/issues/790)

## Description

Unifies the order of parameters for `register` so they are the same in JS, iOS and Android. JS and Android had the same order so I assumed it's best to change in iOS.

## Steps to verify

Was unable to verify with the current state of `main` as there are other errors

Could be tested by calling `await register(registerConfig)` on both iOS and Android and making sure there are no crashes
