### PR TITLE
Fix authorization state parameter in iOS

### DIFF
--- a/.changeset/spicy-knives-play.md
+++ b/.changeset/spicy-knives-play.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+Fix authorization state parameter in iOS when using custom configuration

--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -348,7 +348,7 @@ RCT_REMAP_METHOD(logout,
                                                      scope:[OIDScopeUtilities scopesWithArray:scopes]
                                                redirectURL:[NSURL URLWithString:redirectUrl]
                                               responseType:OIDResponseTypeCode
-                                                     state: additionalParameters[@"state"] ? nil : [[self class] generateState]
+                                                     state: additionalParameters[@"state"] ? additionalParameters[@"state"] : [[self class] generateState]
                                                      nonce:nonce
                                               codeVerifier:codeVerifier
                                              codeChallenge:codeChallenge


### PR DESCRIPTION
Fixes #480 #694 #591

## Description

Need to include the state additional parameter if it is specified

## Steps to verify

on iOS pass state as an additional parameter.
