### PR TITLE
Add asgardeo to the list of tested OpenID providers

### DIFF
--- a/.changeset/yellow-turkeys-hope.md
+++ b/.changeset/yellow-turkeys-hope.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+Added Asgardeo configuration example

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ These providers are OpenID compliant, which means you can use [autodiscovery](ht
 - [Keycloak](http://www.keycloak.org/) ([Example configuration](./docs/config-examples/keycloak.md))
 - [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory) ([Example configuration](./docs/config-examples/azure-active-directory.md))
 - [AWS Cognito](https://eu-west-1.console.aws.amazon.com/cognito) ([Example configuration](./docs/config-examples/aws-cognito.md))
+- [Asgardeo](https://asgardeo.io) ([Example configuration](./docs/config-examples/asgardeo.md))
 
 ### Tested OAuth2 providers
 

--- a/docs/config-examples/asgardeo.md
+++ b/docs/config-examples/asgardeo.md
@@ -1,0 +1,31 @@
+To add authentication to your app using Asgardeo, you will first need to [create an application](https://wso2.com/asgardeo/docs/guides/applications/register-mobile-app/) in the Asgardeo console. If you don't have an Asgardeo account, [you can signup for one free](https://asgardeo.io/signup).
+
+After creating an application, take note of the configuration values listed in the **Quick Start** and **Info** tabs. You will be using those values as follows.
+
+```js
+export const config = {
+  issuer: 'https://api.asgardeo.io/t/<your_org_name>/oauth2/token',
+  clientId: '<your_application_id>',
+  redirectUrl: '<your_appAuthRedirectScheme>://example',
+  scopes: ['openid', 'profile']
+};
+
+// Log in to get an authentication token
+const authState = await authorize(config);
+
+// Refresh token
+const refreshedState = await refresh(config, {
+  refreshToken: authState.refreshToken,
+});
+
+// Revoke token
+await revoke(config, {
+  tokenToRevoke: refreshedState.refreshToken
+});
+
+// End session
+await logout(config, {
+  idToken: authState.idToken,
+  postLogoutRedirectUrl: '<your_appAuthRedirectScheme>:/logout'
+});
+```


### PR DESCRIPTION
Fixes N/A <!-- Link the issue that will be fixed by merging this PR, e.g. Fixes #1234 -->

## Description

<!-- Include a summary of the work -->
This PR adds Asgardeo (https://asgardeo.io), to the list of tested OpenID providers, along with configuration examples documentation.

## Steps to verify

<!-- Describe steps to verify -->
I have written a blog and developed a sample [1], demonstrating Asgardeo integration with a React Native app using react-native-app-auth library.

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->

[1] https://pavindulakshan.com/blog/secure-react-native-apps-with-asgardeo