### PR TITLE
fix: Added `androidTrustedWebActivity` config to opt-in to EXTRA_LAUCH_AS_TRUSTED_WEB_ACTIVITY

### DIFF
--- a/.changeset/two-rice-collect.md
+++ b/.changeset/two-rice-collect.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': minor
+---
+
+Added `androidTrustedWebActivity` config to opt-in to EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ with optional overrides.
 - **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `SFAuthenticationSession` or `SFSafariViewController` are used.
 - **iosPrefersEphemeralSession** - (`boolean`) (default: `false`) _IOS_ indicates whether the session should ask the browser for a private authentication session.
 - **androidAllowCustomBrowsers** - (`string[]`) (default: undefined) _ANDROID_ override the used browser for authorization. If no value is provided, all browsers are allowed.
+- **androidTrustedWebActivity** - (`boolean`) (default: false) _ANDROID_ Use [`EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY`](https://developer.chrome.com/docs/android/trusted-web-activity/) when opening web view.
 - **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds. This must be a positive number. The default values are 60 seconds on iOS and 15 seconds on Android.
 
 #### result

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ with optional overrides.
 - **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `SFAuthenticationSession` or `SFSafariViewController` are used.
 - **iosPrefersEphemeralSession** - (`boolean`) (default: `false`) _IOS_ indicates whether the session should ask the browser for a private authentication session.
 - **androidAllowCustomBrowsers** - (`string[]`) (default: undefined) _ANDROID_ override the used browser for authorization. If no value is provided, all browsers are allowed.
-- **androidTrustedWebActivity** - (`boolean`) (default: false) _ANDROID_ Use [`EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY`](https://developer.chrome.com/docs/android/trusted-web-activity/) when opening web view.
+- **androidTrustedWebActivity** - (`boolean`) (default: `false`) _ANDROID_ Use [`EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY`](https://developer.chrome.com/docs/android/trusted-web-activity/) when opening web view.
 - **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds. This must be a positive number. The default values are 60 seconds on iOS and 15 seconds on Android.
 
 #### result

--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -240,6 +240,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final boolean dangerouslyAllowInsecureHttpRequests,
             final ReadableMap customHeaders,
             final ReadableArray androidAllowCustomBrowsers,
+            final boolean androidTrustedWebActivity,
             final Promise promise
     ) {
         this.parseHeaderMap(customHeaders);
@@ -269,7 +270,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         redirectUrl,
                         useNonce,
                         usePKCE,
-                        additionalParametersMap
+                        additionalParametersMap,
+                        androidTrustedWebActivity
                 );
             } catch (ActivityNotFoundException e) {
                 promise.reject("browser_not_found", e.getMessage());
@@ -300,7 +302,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                         redirectUrl,
                                         useNonce,
                                         usePKCE,
-                                        additionalParametersMap
+                                        additionalParametersMap,
+                                        androidTrustedWebActivity
                                 );
                             } catch (ActivityNotFoundException e) {
                                 promise.reject("browser_not_found", e.getMessage());
@@ -642,7 +645,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final String redirectUrl,
             final Boolean useNonce,
             final Boolean usePKCE,
-            final Map<String, String> additionalParametersMap
+            final Map<String, String> additionalParametersMap,
+            final Boolean androidTrustedWebActivity
     ) {
 
         String scopesString = null;
@@ -717,7 +721,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
 
             CustomTabsIntent.Builder intentBuilder = authService.createCustomTabsIntentBuilder();
             CustomTabsIntent customTabsIntent = intentBuilder.build();
-            customTabsIntent.intent.putExtra(TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true);
+
+            if (androidTrustedWebActivity) {
+                customTabsIntent.intent.putExtra(TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true);
+            }
 
             Intent authIntent = authService.getAuthorizationRequestIntent(authRequest, customTabsIntent);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -88,6 +88,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
     | 'samsung'
     | 'samsungCustomTab'
   )[];
+  androidTrustedWebActivity?: boolean;
   iosPrefersEphemeralSession?: boolean;
 };
 

--- a/index.js
+++ b/index.js
@@ -209,6 +209,7 @@ export const authorize = ({
   skipCodeExchange = false,
   iosCustomBrowser = null,
   androidAllowCustomBrowsers = null,
+  androidTrustedWebActivity = false,
   connectionTimeoutSeconds,
   iosPrefersEphemeralSession = false,
 }) => {
@@ -239,6 +240,7 @@ export const authorize = ({
     nativeMethodArguments.push(dangerouslyAllowInsecureHttpRequests);
     nativeMethodArguments.push(customHeaders);
     nativeMethodArguments.push(androidAllowCustomBrowsers);
+    nativeMethodArguments.push(androidTrustedWebActivity);
   }
 
   if (Platform.OS === 'ios') {

--- a/index.spec.js
+++ b/index.spec.js
@@ -63,6 +63,7 @@ describe('AppAuth', () => {
     iosCustomBrowser: 'safari',
     iosPrefersEphemeralSession: true,
     androidAllowCustomBrowsers: ['chrome'],
+    androidTrustedWebActivity: false,
   };
 
   const registerConfig = {
@@ -738,7 +739,8 @@ describe('AppAuth', () => {
             config.clientAuthMethod,
             false,
             config.customHeaders,
-            config.androidAllowCustomBrowsers
+            config.androidAllowCustomBrowsers,
+            config.androidTrustedWebActivity
           );
         });
       });
@@ -761,7 +763,8 @@ describe('AppAuth', () => {
             config.clientAuthMethod,
             false,
             config.customHeaders,
-            config.androidAllowCustomBrowsers
+            config.androidAllowCustomBrowsers,
+            config.androidTrustedWebActivity
           );
         });
 
@@ -782,7 +785,8 @@ describe('AppAuth', () => {
             config.clientAuthMethod,
             false,
             config.customHeaders,
-            config.androidAllowCustomBrowsers
+            config.androidAllowCustomBrowsers,
+            config.androidTrustedWebActivity
           );
         });
 
@@ -803,7 +807,8 @@ describe('AppAuth', () => {
             config.clientAuthMethod,
             true,
             config.customHeaders,
-            config.androidAllowCustomBrowsers
+            config.androidAllowCustomBrowsers,
+            config.androidTrustedWebActivity
           );
         });
       });
@@ -833,7 +838,8 @@ describe('AppAuth', () => {
             config.clientAuthMethod,
             false,
             customHeaders,
-            config.androidAllowCustomBrowsers
+            config.androidAllowCustomBrowsers,
+            config.androidTrustedWebActivity
           );
         });
       });


### PR DESCRIPTION
Fixes #907

## Description

#747 added `EXTRA_LAUCH_AS_TRUSTED_WEB_ACTIVITY` by default to Android webviews. This PR defaults that back to the original behaviour, but adds  `androidTrustedWebActivity` config option to allow opt-in.


