### PR TITLE
Add documentation for Microsoft SSO

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ These providers are OpenID compliant, which means you can use [autodiscovery](ht
 - [Azure Active Directory](https://docs.microsoft.com/en-us/azure/active-directory) ([Example configuration](./docs/config-examples/azure-active-directory.md))
 - [AWS Cognito](https://eu-west-1.console.aws.amazon.com/cognito) ([Example configuration](./docs/config-examples/aws-cognito.md))
 - [Asgardeo](https://asgardeo.io) ([Example configuration](./docs/config-examples/asgardeo.md))
+- [Microsoft](https://learn.microsoft.com/en-us/entra/identity-platform/v2-protocols-oidc) ([Example configuration](./docs/config-examples/microsoft.md))
 
 ## Tested OAuth2 providers
 

--- a/docs/config-examples/microsoft.md
+++ b/docs/config-examples/microsoft.md
@@ -1,0 +1,29 @@
+## Microsoft
+
+1. Supplying "issuer" fails, because Microsoft returns `issuer` with the literal string `https://login.microsoftonline.com/{tenantid}/v2.0` when `https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration` is queried.. We need to manually specify `serviceConfiguration`.
+
+2. `REDIRECT_URL` varies based on platform:
+   - iOS: msauth.com.example.app://auth/
+   - Android: com.example.app://msauth/<SIGNATURE_HASH>/
+
+3. Microsoft does not have. revocationEndpoint.
+
+```js
+const config = {
+  serviceConfiguration: {
+    authorizationEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
+    tokenEndpoint: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
+  },
+  clientId: '<APPLICATION_ID>',
+  redirectUrl: '<REDIRECT_URL>',
+  scopes: ['openid', 'profile', 'email', 'offline_access'],
+};
+
+// Log in to get an authentication token
+const authState = await authorize(config);
+
+// Refresh token
+const refreshedState = await refresh(config, {
+  refreshToken: authState.refreshToken,
+});
+```


### PR DESCRIPTION
## Description
Add documentation for Microsoft SSO. This is the common endpoint, which allows for sign in with any Microsoft account (public or school/work).
