### PR TITLE
Fix iosCustomBrowser not exchanging token

### DIFF
--- a/ios/RNAppAuth.m
+++ b/ios/RNAppAuth.m
@@ -409,26 +409,30 @@ RCT_REMAP_METHOD(logout,
             }
         }
     } else {
+        OIDAuthStateAuthorizationCallback callback = ^(
+                                                       OIDAuthState *_Nullable authState,
+                                                       NSError *_Nullable error
+                                                       ) {
+                                                           typeof(self) strongSelf = weakSelf;
+                                                           strongSelf->_currentSession = nil;
+                                                           [UIApplication.sharedApplication endBackgroundTask:rnAppAuthTaskId];
+                                                           rnAppAuthTaskId = UIBackgroundTaskInvalid;
+                                                           if (authState) {
+                                                               resolve([self formatResponse:authState.lastTokenResponse
+                                                                           withAuthResponse:authState.lastAuthorizationResponse]);
+                                                           } else {
+                                                               reject([self getErrorCode: error defaultCode:@"authentication_failed"],
+                                                                      [self getErrorMessage: error], error);
+                                                           }
+                                                       };
         
         if(externalUserAgent != nil) {
-            _currentSession = [OIDAuthorizationService presentAuthorizationRequest:request
+            _currentSession = [OIDAuthState authStateByPresentingAuthorizationRequest:request
                                                                     externalUserAgent:externalUserAgent
                                                                              callback:callback];
         } else {
-            OIDAuthStateAuthorizationCallback callback = ^(OIDAuthState *_Nullable authState,
-                                                                NSError *_Nullable error) {
-                                                        typeof(self) strongSelf = weakSelf;
-                                                        strongSelf->_currentSession = nil;
-                                                        [UIApplication.sharedApplication endBackgroundTask:rnAppAuthTaskId];
-                                                        rnAppAuthTaskId = UIBackgroundTaskInvalid;
-                                                        if (authState) {
-                                                            resolve([self formatResponse:authState.lastTokenResponse
-                                                                withAuthResponse:authState.lastAuthorizationResponse]);
-                                                        } else {
-                                                            reject([self getErrorCode: error defaultCode:@"authentication_failed"],
-                                                                   [self getErrorMessage: error], error);
-                                                        }
-                                                    };
+            
+            
             if (@available(iOS 13, *)) {
                 _currentSession = [OIDAuthState authStateByPresentingAuthorizationRequest:request
                                                                  presentingViewController:presentingViewController


### PR DESCRIPTION
Fixes #829

## Description

Use `authStateByPresentingAuthorizationRequest` when `externalUserAgent` is present to exchange the token.

## Steps to verify

```const config: AuthConfiguration = {
  ...
  iosCustomBrowser: 'safari',
  skipCodeExchange: false,
}

const result = await authorize(config);
```

Solution based on comment from https://github.com/FormidableLabs/react-native-app-auth/issues/829#issuecomment-1553160482