### PR TITLE
Fix booleanValue() on a null object on Android

### DIFF
--- a/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -501,7 +501,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 return;
             }
 
-            if (this.skipCodeExchange) {
+            if (this.skipCodeExchange != null && this.skipCodeExchange) {
                 WritableMap map;
                 if (this.usePKCE && this.codeVerifier != null) {
                     map = TokenResponseFactory.authorizationCodeResponseToMap(response, this.codeVerifier);


### PR DESCRIPTION
In some cases the boolean variable skipCodeExchange may be null and cause an error.

Fixes #672 

## Description

 I added a check before using skipCodeExchange. If the variable is null I will consider it false

## Steps to verify

Unable to reproduce. The error occured when skipCodeExchange is strangely null returning in Activity into onActivityResult after authorize()