### PR TITLE
Move @changesets/cli to devDependencies list

### DIFF
--- a/.changeset/bright-trainers-press.md
+++ b/.changeset/bright-trainers-press.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+Moves '@changesets/cli' from dependencies to devDependencies, so that it isn't downloaded for react-native-app-auth package users

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "react-native": ">=0.63.0"
   },
   "devDependencies": {
+    "@changesets/cli": "^2.26.1",
     "@svitejs/changesets-changelog-github-compact": "^0.1.1",
     "babel-eslint": "10.0.3",
     "eslint": "6.8.0",
@@ -65,7 +66,6 @@
     "react-native": "0.61.5"
   },
   "dependencies": {
-    "@changesets/cli": "^2.26.1",
     "invariant": "2.2.4",
     "react-native-base64": "0.0.2"
   },


### PR DESCRIPTION
Prevents users of this package from having to download `@changesets/cli` (and all it's dependencies)