### PR TITLE
AppAuth version updated for Apple Privacy Manifest for AppAuth-iOS

### DIFF
--- a/.changeset/sixty-insects-know.md
+++ b/.changeset/sixty-insects-know.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': minor
+---
+
+Updated the minimum version of AppAuth-iOS to 1.7.3 to meet the package's requirement, which includes the necessary privacy manifest.

--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AppAuth (1.6.2):
-    - AppAuth/Core (= 1.6.2)
-    - AppAuth/ExternalUserAgent (= 1.6.2)
-  - AppAuth/Core (1.6.2)
-  - AppAuth/ExternalUserAgent (1.6.2):
+  - AppAuth (1.7.5):
+    - AppAuth/Core (= 1.7.5)
+    - AppAuth/ExternalUserAgent (= 1.7.5)
+  - AppAuth/Core (1.7.5)
+  - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
   - boost (1.76.0)
   - CocoaAsyncSocket (7.6.5)
@@ -381,8 +381,8 @@ PODS:
   - React-jsinspector (0.72.4)
   - React-logger (0.72.4):
     - glog
-  - react-native-app-auth (7.0.0-rc2):
-    - AppAuth (~> 1.6)
+  - react-native-app-auth (7.1.3):
+    - AppAuth (>= 1.7.3)
     - React-Core
   - React-NativeModulesApple (0.72.4):
     - hermes-engine
@@ -667,7 +667,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  AppAuth: 3bb1d1cd9340bd09f5ed189fb00b1cc28e1e8570
+  AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
@@ -701,7 +701,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c7f826e40fa9cab5d37cab6130b1af237332b594
   React-jsinspector: aaed4cf551c4a1c98092436518c2d267b13a673f
   React-logger: da1ebe05ae06eb6db4b162202faeafac4b435e77
-  react-native-app-auth: 05c3b875b27bb65fe321bd5dc38cc1c04c5158be
+  react-native-app-auth: 7ceb3031aa96ad0daba15bee3b379f9d106c5abd
   React-NativeModulesApple: edb5ace14f73f4969df6e7b1f3e41bef0012740f
   React-perflogger: 496a1a3dc6737f964107cb3ddae7f9e265ddda58
   React-RCTActionSheet: 02904b932b50e680f4e26e7a686b33ebf7ef3c00
@@ -725,4 +725,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 90be020bf55058ddd450ae593af00b72ed3379ce
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.15.2

--- a/react-native-app-auth.podspec
+++ b/react-native-app-auth.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'React-Core'
-  s.dependency 'AppAuth', '~> 1.6'
+  s.dependency 'AppAuth', '>= 1.7.3'
 end


### PR DESCRIPTION
Fixes #954

## Description
Updated the minimum version from 1.6 to [1.7.3](https://github.com/openid/AppAuth-iOS/releases/tag/1.7.3) for AppAuth-iOS required by this package as it has the required privacy manifest included with it.

From the issue:

> Apple's Privacy manifest requirement is required by May 1st.
> https://developer.apple.com/news/?id=3d8a9yyh
> 
> AppAuth is mentioned in the SDKs that require a privacy manifest and signature:
> https://developer.apple.com/support/third-party-SDK-requirements/
> 
> It looks like the AppAuth-iOS pod released the version that has the privacy manifest recently:
> https://github.com/openid/AppAuth-iOS/releases/tag/1.7.3

## Steps to verify

Run the Example app to verify the version installed by `pod install`

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
