### PR TITLE
Correct the docs regarding iOS auth methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ These providers implement the OAuth2 spec, but are not OpenID providers, which m
 
 AppAuth is a mature OAuth client implementation that follows the best practices set out in
 [RFC 8252 - OAuth 2.0 for Native Apps](https://tools.ietf.org/html/rfc8252) including using
-`SFAuthenticationSession` and `SFSafariViewController` on iOS, and
+`ASWebAuthenticationSession` and `SFSafariViewController` on iOS, and
 [Custom Tabs](http://developer.android.com/tools/support-library/features.html#custom-tabs) on
 Android. `WebView`s are explicitly _not_ supported due to the security and usability reasons
 explained in [Section 8.12 of RFC 8252](https://tools.ietf.org/html/rfc8252#section-8.12).

--- a/docs/docs/usage/config.md
+++ b/docs/docs/usage/config.md
@@ -46,7 +46,7 @@ See specific example [configurations for your provider](/docs/category/providers
 - **useNonce** - (`boolean`) (default: true) optionally allows not sending the nonce parameter, to support non-compliant providers. To specify custom nonce, provide it in `additionalParameters` under the `nonce` key.
 - **usePKCE** - (`boolean`) (default: true) optionally allows not sending the code_challenge parameter and skipping PKCE code verification, to support non-compliant providers.
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)
-- **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `SFAuthenticationSession` or `SFSafariViewController` are used.
+- **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `ASWebAuthenticationSession` or `SFSafariViewController` are used by the `AppAuth-iOS` library.
 - **iosPrefersEphemeralSession** - (`boolean`) (default: `false`) _IOS_ indicates whether the session should ask the browser for a private authentication session.
 - **androidAllowCustomBrowsers** - (`string[]`) (default: undefined) _ANDROID_ override the used browser for authorization. If no value is provided, all browsers are allowed.
 - **androidTrustedWebActivity** - (`boolean`) (default: `false`) _ANDROID_ Use [`EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY`](https://developer.chrome.com/docs/android/trusted-web-activity/) when opening web view.


### PR DESCRIPTION
As of version 1.5 of AppAuth-iOS, we now use `ASWebAuthenticationSession` which was released in [7.0.0](https://github.com/FormidableLabs/react-native-app-auth/releases/tag/v7.0.0)