### PR TITLE
fix: iOS crash when scenes are enabled

### DIFF
--- a/.changeset/ten-needles-heal.md
+++ b/.changeset/ten-needles-heal.md
@@ -1,0 +1,5 @@
+---
+"react-native-app-auth": patch
+---
+
+fix: iOS crash when scenes are enabled

--- a/packages/react-native-app-auth/ios/RNAppAuth.m
+++ b/packages/react-native-app-auth/ios/RNAppAuth.m
@@ -130,7 +130,7 @@ RCT_REMAP_METHOD(authorize,
                                                                     return;
                                                                 }
                                                                 [self authorizeWithConfiguration: configuration
-                                                                 
+
                                                                                      redirectUrl: redirectUrl
                                                                                         clientId: clientId
                                                                                     clientSecret: clientSecret
@@ -343,7 +343,7 @@ RCT_REMAP_METHOD(logout,
     OIDAuthorizationRequest *request =
     [[OIDAuthorizationRequest alloc] initWithConfiguration:configuration
                                                   clientId:clientId
-     
+
                                               clientSecret:clientSecret
                                                      scope:[OIDScopeUtilities scopesWithArray:scopes]
                                                redirectURL:[NSURL URLWithString:redirectUrl]
@@ -371,12 +371,16 @@ RCT_REMAP_METHOD(logout,
 
     UIViewController *presentingViewController = appDelegate.window.rootViewController.view.window ? appDelegate.window.rootViewController : appDelegate.window.rootViewController.presentedViewController;
 
+    if (!presentingViewController) {
+        presentingViewController = RCTPresentedViewController();
+    }
+
 #if TARGET_OS_MACCATALYST
     id<OIDExternalUserAgent> externalUserAgent = nil;
 #elif TARGET_OS_IOS
     id<OIDExternalUserAgent> externalUserAgent = iosCustomBrowser != nil ? [self getCustomBrowser: iosCustomBrowser] : nil;
 #endif
-    
+
     OIDAuthorizationCallback callback = ^(OIDAuthorizationResponse *_Nullable authorizationResponse, NSError *_Nullable error) {
                                                    typeof(self) strongSelf = weakSelf;
                                                    strongSelf->_currentSession = nil;
@@ -391,7 +395,7 @@ RCT_REMAP_METHOD(logout,
                                                };
 
     if (skipCodeExchange) {
-        
+
         if(externalUserAgent != nil) {
             _currentSession = [OIDAuthorizationService presentAuthorizationRequest:request
                                                                  externalUserAgent:externalUserAgent
@@ -425,14 +429,14 @@ RCT_REMAP_METHOD(logout,
                                                                       [self getErrorMessage: error], error);
                                                            }
                                                        };
-        
+
         if(externalUserAgent != nil) {
             _currentSession = [OIDAuthState authStateByPresentingAuthorizationRequest:request
                                                                     externalUserAgent:externalUserAgent
                                                                              callback:callback];
         } else {
-            
-            
+
+
             if (@available(iOS 13, *)) {
                 _currentSession = [OIDAuthState authStateByPresentingAuthorizationRequest:request
                                                                  presentingViewController:presentingViewController
@@ -520,7 +524,7 @@ RCT_REMAP_METHOD(logout,
     id<OIDExternalUserAgent> externalUserAgent = iosCustomBrowser != nil ? [self getCustomBrowser: iosCustomBrowser] : [self getExternalUserAgentWithPresentingViewController:presentingViewController
                                                                                                                                     prefersEphemeralSession:prefersEphemeralSession];
 #endif
-    
+
     _currentSession = [OIDAuthorizationService presentEndSessionRequest: endSessionRequest
                                                       externalUserAgent: externalUserAgent
                                              callback: ^(OIDEndSessionResponse *_Nullable response, NSError *_Nullable error) {
@@ -697,7 +701,7 @@ RCT_REMAP_METHOD(logout,
 #if !TARGET_OS_MACCATALYST
 - (id<OIDExternalUserAgent>)getCustomBrowser: (NSString *) browserType {
     typedef id<OIDExternalUserAgent> (^BrowserBlock)(void);
-    
+
     NSDictionary *browsers = @{
         @"safari":
             ^{


### PR DESCRIPTION
Fixes #... <!-- Link the issue that will be fixed by merging this PR, e.g. Fixes #1234 -->

## Description

<!-- Include a summary of the work -->
iOS crashes when presenting a view controller while the application is using scenes: https://developer.apple.com/documentation/uikit/app_and_environment/scenes/
The issue occurs because each scene has its own window.
```
UIViewController *presentingViewController = appDelegate.window.rootViewController.view.window ? appDelegate.window.rootViewController : appDelegate.window.rootViewController.presentedViewController;
```
presentingViewController returns nil
![IMG_7244](https://github.com/FormidableLabs/react-native-app-auth/assets/6761714/39369a54-3927-444a-a92c-f0b395cfc9b0)


## Steps to verify

<!-- Describe steps to verify -->
1. Prepare an application where scenes are enabled: https://developer.apple.com/documentation/uikit/app_and_environment/scenes/specifying_the_scenes_your_app_supports#3262273
2. On the RN side, call authorize from "react-native-app-auth"
<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
