### PR TITLE
docs: Update OS projects to show projects more relevant to React native

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -56,7 +56,7 @@ export default function Home(): JSX.Element {
           },
           {
             name: 'owl',
-            title: 'React Native OWL',
+            title: 'React Native Owl',
             link: 'https://commerce.nearform.com/open-source/react-native-owl/',
             description:
               'Visual Regression Testing for React Native',

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -49,27 +49,31 @@ export default function Home(): JSX.Element {
         heading="Other Open Source from Nearform_Commerce"
         projects={[
           {
-            name: 'nuka',
-            link: 'https://commerce.nearform.com/open-source/nuka-carousel',
-            description:
-              'Small, fast and accessibility-first React carousel library with easily customizable UI and behavior to fit your brand and site.',
-          },
-          {
-            name: 'spectacle',
-            link: 'https://commerce.nearform.com/open-source/spectacle',
-            description:
-              'A React.js based library for creating sleek presentations using JSX syntax with the ability to live demo your code!',
-          },
-          {
-            name: 'envy',
-            link: 'https://github.com/FormidableLabs/envy',
-            description:
-              'Envy will trace the network calls from every application in your stack and allow you to view them in a central place.',
-          },
-          {
             name: 'victory',
-            link: 'https://commerce.nearform.com/open-source/victory/',
-            description: 'React.js components for modular charting and data visualization.',
+            title: 'Victory Native',
+            link: 'https://commerce.nearform.com/open-source/victory-native/',
+            description: 'A charting library for React Native with a focus on performance and customization.',
+          },
+          {
+            name: 'owl',
+            title: 'React Native OWL',
+            link: 'https://commerce.nearform.com/open-source/react-native-owl/',
+            description:
+              'Visual Regression Testing for React Native',
+          },
+          {
+            name: 'urql',
+            title:'URQL',
+            link: 'https://commerce.nearform.com/open-source/urql',
+            description:
+              'The highly customizable and versatile GraphQL client for React, Svelte, Vue, or plain JavaScript, with which you add on features like normalized caching as you grow.',
+          },
+          {
+            name: 'groqd',
+            title: 'GROQD',
+            link: 'https://commerce.nearform.com/open-source/groqd',
+            description:
+              'Typesafe Query Builder for GROQ, Sanity\'s open-source query language',
           },
         ]}
       />


### PR DESCRIPTION

## Description

Updates the list of other OS projects in the docs to contain projects more relevant to React Native.

## Steps to verify

The changes have been checked by running the docs locally.

| Before | After |
|--------|--------|
| ![Screenshot 2024-07-18 at 17 22 21](https://github.com/user-attachments/assets/8a9a0c81-26aa-4702-9548-f3ee9daf21e7) | ![Screenshot 2024-07-18 at 17 18 29](https://github.com/user-attachments/assets/2433c87b-097a-4d12-b0a6-a30b10e119f3) | 
