### PR TITLE
fix(ios): marshal booleans correctly (#999, #980)

### DIFF
--- a/.changeset/olive-terms-check.md
+++ b/.changeset/olive-terms-check.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': major
+---
+
+Breaking change (iOS, Mac Catalyst): The boolean values `useNonce`, `usePCKE`, and `prefersEphemeralSession` are now handled correctly. Previously, they were all being interpreted as `false` regardless of their actual values, but now the intended (`true` or `false`) value is correctly marshalled from JavaScript to native. To preserve behaviour from before this breaking change, explicitly set them all to `false`.

--- a/packages/react-native-app-auth/ios/RNAppAuth.m
+++ b/packages/react-native-app-auth/ios/RNAppAuth.m
@@ -97,10 +97,10 @@ RCT_REMAP_METHOD(authorize,
                  skipCodeExchange: (BOOL) skipCodeExchange
                  connectionTimeoutSeconds: (double) connectionTimeoutSeconds
                  additionalHeaders: (NSDictionary *_Nullable) additionalHeaders
-                 useNonce: (BOOL *) useNonce
-                 usePKCE: (BOOL *) usePKCE
+                 useNonce: (BOOL) useNonce
+                 usePKCE: (BOOL) usePKCE
                  iosCustomBrowser: (NSString *) iosCustomBrowser
-                 prefersEphemeralSession: (BOOL *) prefersEphemeralSession
+                 prefersEphemeralSession: (BOOL) prefersEphemeralSession
                  resolve: (RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
@@ -204,7 +204,7 @@ RCT_REMAP_METHOD(logout,
                  serviceConfiguration: (NSDictionary *_Nullable) serviceConfiguration
                  additionalParameters: (NSDictionary *_Nullable) additionalParameters
                  iosCustomBrowser: (NSString *) iosCustomBrowser
-                 prefersEphemeralSession: (BOOL *) prefersEphemeralSession
+                 prefersEphemeralSession: (BOOL) prefersEphemeralSession
                  resolve:(RCTPromiseResolveBlock) resolve
                  reject: (RCTPromiseRejectBlock)  reject)
 {
@@ -325,12 +325,12 @@ RCT_REMAP_METHOD(logout,
                           clientId: (NSString *) clientId
                       clientSecret: (NSString *) clientSecret
                             scopes: (NSArray *) scopes
-                          useNonce: (BOOL *) useNonce
-                           usePKCE: (BOOL *) usePKCE
+                          useNonce: (BOOL) useNonce
+                           usePKCE: (BOOL) usePKCE
               additionalParameters: (NSDictionary *_Nullable) additionalParameters
               skipCodeExchange: (BOOL) skipCodeExchange
                   iosCustomBrowser: (NSString *) iosCustomBrowser
-           prefersEphemeralSession: (BOOL *) prefersEphemeralSession
+           prefersEphemeralSession: (BOOL) prefersEphemeralSession
                            resolve: (RCTPromiseResolveBlock) resolve
                             reject: (RCTPromiseRejectBlock)  reject
 {
@@ -489,7 +489,7 @@ RCT_REMAP_METHOD(logout,
               postLogoutRedirectURL: (NSString *) postLogoutRedirectURL
                additionalParameters: (NSDictionary *_Nullable) additionalParameters
                    iosCustomBrowser: (NSString *) iosCustomBrowser
-            prefersEphemeralSession: (BOOL *) prefersEphemeralSession
+            prefersEphemeralSession: (BOOL) prefersEphemeralSession
                             resolve: (RCTPromiseResolveBlock) resolve
                              reject: (RCTPromiseRejectBlock) reject {
 
@@ -734,7 +734,7 @@ RCT_REMAP_METHOD(logout,
 }
 
 - (id<OIDExternalUserAgent>)getExternalUserAgentWithPresentingViewController: (UIViewController *)presentingViewController
-                                                     prefersEphemeralSession: (BOOL *) prefersEphemeralSession
+                                                     prefersEphemeralSession: (BOOL) prefersEphemeralSession
 {
   id<OIDExternalUserAgent> externalUserAgent;
   #if TARGET_OS_MACCATALYST


### PR DESCRIPTION
Fixes #999 and #980

## Description

Changes the method signatures from `(BOOL *)` (which marshals both `true` and `false` from JS to `NO` in Objective-C) to `(BOOL)` (which correctly marshals `true` to `YES` and `false` to `NO`).

## Steps to verify

1. Set a breakpoint inside the iOS `authorize` method.
2. Confirm that `useNonce = true` from JavaScript now becomes `YES` instead of `NO`.