### PR TITLE
fix metro for example app for iOS

### DIFF
--- a/examples/demo/metro.config.js
+++ b/examples/demo/metro.config.js
@@ -6,10 +6,13 @@ const packagePath = path.resolve(
   path.join(process.cwd(), '..', '..', 'packages', 'react-native-app-auth'),
 );
 
+const projectRoot = __dirname;
+const monorepoRoot = path.resolve(projectRoot, '../..');
+
 const extraNodeModules = {
   'react-native-app-auth': packagePath,
 };
-const watchFolders = [packagePath];
+const watchFolders = [monorepoRoot, packagePath];
 
 /**
  * Metro configuration
@@ -29,5 +32,10 @@ const config = {
   },
   watchFolders,
 };
+
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, 'node_modules'),
+  path.resolve(monorepoRoot, 'node_modules'),
+];
 
 module.exports = mergeConfig(getDefaultConfig(__dirname), config);


### PR DESCRIPTION
## Description

Fixes metro with monorepo: https://docs.expo.dev/guides/monorepos/#modify-the-metro-config

I missed with #988 when verifying it worked on iOS that I hadn't cleared my node modules before running, so all the deps worked fine. But if someone were to clone the repo from fresh and try, they'd run into metro errors.


## Steps to verify

Clone the repo and follow the install and running steps and see the app work.

<!-- Describe steps to verify -->

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
