### PR TITLE
fix: prefetch crash

### DIFF
--- a/.changeset/short-lies-behave.md
+++ b/.changeset/short-lies-behave.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+fix hard crash if config object was incorrect

--- a/packages/react-native-app-auth/index.js
+++ b/packages/react-native-app-auth/index.js
@@ -4,29 +4,31 @@ import base64 from 'react-native-base64';
 
 const { RNAppAuth } = NativeModules;
 
-const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfiguration) =>
+const validateIssuer = issuer => typeof issuer === 'string' && issuer.length;
+const validateIssuerOrServiceConfigurationEndpoints = (issuer, serviceConfiguration) => {
   invariant(
-    typeof issuer === 'string' ||
+    validateIssuer(issuer) ||
       (serviceConfiguration &&
         typeof serviceConfiguration.authorizationEndpoint === 'string' &&
         typeof serviceConfiguration.tokenEndpoint === 'string'),
     'Config error: you must provide either an issuer or a service endpoints'
   );
+};
 const validateIssuerOrServiceConfigurationRegistrationEndpoint = (issuer, serviceConfiguration) =>
   invariant(
-    typeof issuer === 'string' ||
+    validateIssuer(issuer) ||
       (serviceConfiguration && typeof serviceConfiguration.registrationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a registration endpoint'
   );
 const validateIssuerOrServiceConfigurationRevocationEndpoint = (issuer, serviceConfiguration) =>
   invariant(
-    typeof issuer === 'string' ||
+    validateIssuer(issuer) ||
       (serviceConfiguration && typeof serviceConfiguration.revocationEndpoint === 'string'),
     'Config error: you must provide either an issuer or a revocation endpoint'
   );
 const validateIssuerOrServiceConfigurationEndSessionEndpoint = (issuer, serviceConfiguration) =>
   invariant(
-    typeof issuer === 'string' ||
+    validateIssuer(issuer) ||
       (serviceConfiguration && typeof serviceConfiguration.endSessionEndpoint === 'string'),
     'Config error: you must provide either an issuer or an end session endpoint'
   );


### PR DESCRIPTION
Fixes #478 

## Description

it was possible that the issuer could be an empty string ('') which would indeed cause the app to crash, since our `invariant` check missed that.

This is a required field, and the docs mention it, and the user must supply it in order for the functionality to work, but in the case that it's missed or forgotten, this is better than hard crashing as it was.

## Steps to verify

- before fix, set `issuer: '',` and see app hard crash
- after fix, app doesn't hard crash

