### PR TITLE
Update AppAuth-iOS to version 1.7.6

### DIFF
--- a/.changeset/tidy-students-drive.md
+++ b/.changeset/tidy-students-drive.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+Update AppAuth-iOS to version 1.7.6

--- a/packages/react-native-app-auth/react-native-app-auth.podspec
+++ b/packages/react-native-app-auth/react-native-app-auth.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files  = 'ios/**/*.{h,m}'
   s.requires_arc = true
   s.dependency 'React-Core'
-  s.dependency 'AppAuth', '>= 1.7.3'
+  s.dependency 'AppAuth', '>= 1.7.6'
 end


### PR DESCRIPTION
Update AppAuth-iOS to [version 1.7.6](https://github.com/openid/AppAuth-iOS/releases/tag/1.7.6) which contains a [fix for custom browsers](https://github.com/openid/AppAuth-iOS/pull/871).