### PR TITLE
engines node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
       "**/@react-native/**",
       "**/react-native-app-auth/**"
     ]
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
## Description

add node version to `engines`, helps move to vercel's supported versions of node in 2025
