### PR TITLE
fix: add null check for endSessionPromise

### DIFF
--- a/packages/react-native-app-auth/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/packages/react-native-app-auth/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -578,8 +578,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 return;
             }
             final Promise endSessionPromise = this.promise;
-            WritableMap map = EndSessionResponseFactory.endSessionResponseToMap(response);
-            endSessionPromise.resolve(map);
+            if (endSessionPromise != null) {
+                WritableMap map = EndSessionResponseFactory.endSessionResponseToMap(response);
+                endSessionPromise.resolve(map);
+            }
         }
     } catch (Exception e) {
         if(promise != null) {


### PR DESCRIPTION
## Description

Our team has been affected by a crash on Android and following the stack trace, this is what we see:

```
Exception java.lang.NullPointerException: Attempt to invoke interface method 'void com.facebook.react.bridge.Promise.resolve(java.lang.Object)' on a null object reference
  at com.rnappauth.RNAppAuthModule.onActivityResult (RNAppAuthModule.java:582)
```

We haven't been able to reproduce in our devices yet, but we do see that the following line doesn't have the null check that other promises have in this file:

```java
            final Promise endSessionPromise = this.promise;
            WritableMap map = EndSessionResponseFactory.endSessionResponseToMap(response);
            endSessionPromise.resolve(map);
```

We believe that by adding a null pointer check on the endSessionPromise, we can remove this exception.
