### PR TITLE
fix(getCustomBrowser): explicitly set browser to nil if type not found

### DIFF
--- a/.changeset/nervous-donuts-relate.md
+++ b/.changeset/nervous-donuts-relate.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+#1063 Updated getCustomBrowser: in RNAppAuth.m to explicitly check the return value of browser. If the value is not in the dictionary, it will return nil to trigger an ephemeral session.

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ android/gradle/
 android/gradlew
 android/gradlew.bat
 
+# Android/Eclipse
+#
+android/.settings/
+
 # node.js
 #
 node_modules/

--- a/packages/react-native-app-auth/ios/RNAppAuth.m
+++ b/packages/react-native-app-auth/ios/RNAppAuth.m
@@ -717,6 +717,9 @@ RCT_REMAP_METHOD(logout,
             }
     };
     BrowserBlock browser = browsers[browserType];
+    if (!browser) {
+        return nil;
+    }
     return browser();
 }
 #endif


### PR DESCRIPTION
Fixes #1063 

## Description

This pull request fixes an issue in the `getCustomBrowser:` method where an invalid or empty browser type (e.g., an empty string or NSNull) received from the JavaScript layer would not be properly handled. In iOS release builds, such values caused the method to pass a non-nil result, leading to an attempt to execute an invalid browser block and resulting in a crash.

- Updated `getCustomBrowser:` in `RNAppAuth.m` to explicitly check the return value of `browser`. If the value is not in the dictionary, it will return `nil` to trigger an ephemeral session. 
- Updated gitignore.

## Steps to verify

1. Configure the authorize method with a configuration object with no `iosCustomBrowser`, that includes:
```
const config = {
  issuer: "https://youridprovider.com",
  clientId: "yourClientID",
  redirectUrl: "yourapp://callback",
  scopes: ["openid"],
  iosPrefersEphemeralSession: true,
  usePKCE: true,
};
```
2. Call authorize(config) in your React Native code.
3. Build the app in iOS release mode (the issue is only reproducible in release builds for iOS).
4. Observe that the app not crashes.
