### PR TITLE
fix(iOS): Handle `NSNull` in `iosCustomBrowser` param for logout

### DIFF
--- a/packages/react-native-app-auth/ios/RNAppAuth.m
+++ b/packages/react-native-app-auth/ios/RNAppAuth.m
@@ -517,8 +517,13 @@ RCT_REMAP_METHOD(logout,
 #if TARGET_OS_MACCATALYST
     id<OIDExternalUserAgent> externalUserAgent = nil;
 #elif TARGET_OS_IOS
-    id<OIDExternalUserAgent> externalUserAgent = iosCustomBrowser != nil ? [self getCustomBrowser: iosCustomBrowser] : [self getExternalUserAgentWithPresentingViewController:presentingViewController
-                                                                                                                                    prefersEphemeralSession:prefersEphemeralSession];
+    id<OIDExternalUserAgent> externalUserAgent;
+    if (iosCustomBrowser != nil && ![iosCustomBrowser isEqual:[NSNull null]]) {
+      externalUserAgent = [self getCustomBrowser:iosCustomBrowser];
+    } else {
+      externalUserAgent = [self getExternalUserAgentWithPresentingViewController:presentingViewController
+                                                       prefersEphemeralSession:prefersEphemeralSession];
+    }
 #endif
     
     _currentSession = [OIDAuthorizationService presentEndSessionRequest: endSessionRequest


### PR DESCRIPTION
## Description

While there isn't an issue created specifically for what this PR is attempting to address, there are a few issues that seem to be related to it.

#1061 for example, which led to the fix introduced by #1064 addressed an issue on the `authorize` function. 

Unfortunately, the `logout` function is still failing to properly display the browser, causing the flow to silently fail when `iosCustomBrowser` is not provided, as the call to `[self getCustomBrowser:NSNull]` returns `nil`. 

This seems to be happening on RN V0.77.1 with the new architecture enabled. Untested on other versions.

This PR adds a guard to fallback to the default external user agent when `iosCustomBrowser` is `nil` or `NSNull`.

## Steps to verify

1. Configure the configuration object with no value for the `iosCustomBrowser` option that includes:

```js
const config = {
  issuer: "https://youridprovider.com",
  clientId: "yourClientID",
  redirectUrl: "yourapp://callback",
  scopes: ["openid"],
  iosPrefersEphemeralSession: true,
  usePKCE: true,
};
```

2. Add the calls accordingly for `authorize(config)` and `logout(config)` in your code.
3. Build the app in **iOS release mode**.
4. Execute the `authorize` (login) and `logout` calls via your application.
5. Observe that the default browser is displayed properly.
