### PR TITLE
feat: ephemeral session on android

### DIFF
--- a/.changeset/android-ephemeral-session.md
+++ b/.changeset/android-ephemeral-session.md
@@ -1,0 +1,7 @@
+---
+'react-native-app-auth': minor
+---
+
+Add `androidPrefersEphemeralSession` to request ephemeral Custom Tabs on Android when supported.
+
+This updates AndroidX Browser to 1.9.0, which requires consuming Android projects to build with compile SDK 36 or later and Android Gradle Plugin 8.9.1 or later. Runtime Android support is unchanged; the minimum SDK remains 21.

--- a/.changeset/android-ephemeral-session.md
+++ b/.changeset/android-ephemeral-session.md
@@ -4,4 +4,4 @@
 
 Add `androidPrefersEphemeralSession` to request ephemeral Custom Tabs on Android when supported.
 
-This updates AndroidX Browser to 1.9.0, which requires consuming Android projects to build with compile SDK 36 or later and Android Gradle Plugin 8.9.1 or later. Runtime Android support is unchanged; the minimum SDK remains 21.
+This also updates AndroidX Browser to 1.9.0, so Android projects now need min SDK 21+, compile SDK 36+, and Android Gradle Plugin 8.9.1+.

--- a/docs/docs/usage/config.md
+++ b/docs/docs/usage/config.md
@@ -48,6 +48,7 @@ See specific example [configurations for your provider](/docs/category/providers
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)
 - **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `ASWebAuthenticationSession` or `SFSafariViewController` are used by the `AppAuth-iOS` library.
 - **iosPrefersEphemeralSession** - (`boolean`) (default: `false`) _IOS_ indicates whether the session should ask the browser for a private authentication session.
+-**androidPrefersEphemeralSession** - (`boolean`) (default: `false`) _ANDROID_ indicates whether the session should ask the browser for a private authentication session.
 - **androidAllowCustomBrowsers** - (`string[]`) (default: undefined) _ANDROID_ override the used browser for authorization. If no value is provided, all browsers are allowed.
 - **androidTrustedWebActivity** - (`boolean`) (default: `false`) _ANDROID_ Use [`EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY`](https://developer.chrome.com/docs/android/trusted-web-activity/) when opening web view.
 - **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds. This must be a positive number. The default values are 60 seconds on iOS and 15 seconds on Android.

--- a/docs/docs/usage/config.md
+++ b/docs/docs/usage/config.md
@@ -48,7 +48,7 @@ See specific example [configurations for your provider](/docs/category/providers
 - **skipCodeExchange** - (`boolean`) (default: false) just return the authorization response, instead of automatically exchanging the authorization code. This is useful if this exchange needs to be done manually (not client-side)
 - **iosCustomBrowser** - (`string`) (default: undefined) _IOS_ override the used browser for authorization, used to open an external browser. If no value is provided, the `ASWebAuthenticationSession` or `SFSafariViewController` are used by the `AppAuth-iOS` library.
 - **iosPrefersEphemeralSession** - (`boolean`) (default: `false`) _IOS_ indicates whether the session should ask the browser for a private authentication session.
--**androidPrefersEphemeralSession** - (`boolean`) (default: `false`) _ANDROID_ indicates whether the session should ask the browser for a private authentication session.
+- **androidPrefersEphemeralSession** - (`boolean`) (default: `false`) _ANDROID_ indicates whether the session should ask the browser for a private authentication session when supported.
 - **androidAllowCustomBrowsers** - (`string[]`) (default: undefined) _ANDROID_ override the used browser for authorization. If no value is provided, all browsers are allowed.
 - **androidTrustedWebActivity** - (`boolean`) (default: `false`) _ANDROID_ Use [`EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY`](https://developer.chrome.com/docs/android/trusted-web-activity/) when opening web view.
 - **connectionTimeoutSeconds** - (`number`) configure the request timeout interval in seconds. This must be a positive number. The default values are 60 seconds on iOS and 15 seconds on Android.

--- a/examples/demo/android/build.gradle
+++ b/examples/demo/android/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     ext {
         buildToolsVersion = "35.0.0"
         minSdkVersion = 24
-        compileSdkVersion = 35
+        compileSdkVersion = 36
         targetSdkVersion = 35
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.0.21"
@@ -12,7 +12,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.9.1")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
     }

--- a/packages/react-native-app-auth/android/build.gradle
+++ b/packages/react-native-app-auth/android/build.gradle
@@ -62,5 +62,5 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation 'net.openid:appauth:0.11.1'
-    implementation 'androidx.browser:browser:1.4.0'
+    implementation 'androidx.browser:browser:1.9.0'
 }

--- a/packages/react-native-app-auth/android/build.gradle
+++ b/packages/react-native-app-auth/android/build.gradle
@@ -27,7 +27,7 @@ android {
 
     compileSdkVersion safeExtGet('compileSdkVersion', 36)
     defaultConfig {
-        minSdkVersion safeExtGet('minSdkVersion', 16)
+        minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 34)
         versionCode 1
         versionName "1.0"

--- a/packages/react-native-app-auth/android/build.gradle
+++ b/packages/react-native-app-auth/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
             google()
         }
         dependencies {
-            classpath 'com.android.tools.build:gradle:8.5.2'
+            classpath 'com.android.tools.build:gradle:8.9.1'
         }
     }
 }
@@ -25,7 +25,7 @@ android {
       namespace "com.rnappauth"
     }
 
-    compileSdkVersion safeExtGet('compileSdkVersion', 34)
+    compileSdkVersion safeExtGet('compileSdkVersion', 36)
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 34)

--- a/packages/react-native-app-auth/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/packages/react-native-app-auth/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -243,6 +243,7 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final ReadableMap customHeaders,
             final ReadableArray androidAllowCustomBrowsers,
             final boolean androidTrustedWebActivity,
+            final boolean androidPrefersEphemeralSession,
             final Promise promise) {
         this.parseHeaderMap(customHeaders);
         final ConnectionBuilder builder = createConnectionBuilder(dangerouslyAllowInsecureHttpRequests,
@@ -277,7 +278,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                         useNonce,
                         usePKCE,
                         additionalParametersMap,
-                        androidTrustedWebActivity);
+                        androidTrustedWebActivity,
+                        androidPrefersEphemeralSession);
             } catch (ActivityNotFoundException e) {
                 promise.reject("browser_not_found", e.getMessage());
             } catch (Exception e) {
@@ -308,7 +310,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                                         useNonce,
                                         usePKCE,
                                         additionalParametersMap,
-                                        androidTrustedWebActivity);
+                                        androidTrustedWebActivity,
+                                        androidPrefersEphemeralSession);
                             } catch (ActivityNotFoundException e) {
                                 promise.reject("browser_not_found", e.getMessage());
                             } catch (Exception e) {
@@ -660,7 +663,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             final Boolean useNonce,
             final Boolean usePKCE,
             final Map<String, String> additionalParametersMap,
-            final Boolean androidTrustedWebActivity) {
+            final Boolean androidTrustedWebActivity,
+            final Boolean androidPrefersEphemeralSession) {
 
         String scopesString = null;
 
@@ -731,8 +735,8 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
             AuthorizationService authService = new AuthorizationService(context, appAuthConfiguration);
 
             CustomTabsIntent.Builder intentBuilder = authService.createCustomTabsIntentBuilder();
-            CustomTabsIntent customTabsIntent = intentBuilder.build();
-
+            CustomTabsIntent customTabsIntent = intentBuilder.setEphemeralBrowsingEnabled(androidPrefersEphemeralSession).build();
+            
             if (androidTrustedWebActivity) {
                 customTabsIntent.intent.putExtra(TrustedWebUtils.EXTRA_LAUNCH_AS_TRUSTED_WEB_ACTIVITY, true);
             }

--- a/packages/react-native-app-auth/index.d.ts
+++ b/packages/react-native-app-auth/index.d.ts
@@ -89,6 +89,7 @@ export type AuthConfiguration = BaseAuthConfiguration & {
     | 'samsungCustomTab'
   )[];
   androidTrustedWebActivity?: boolean;
+  androidPrefersEphemeralSession?: boolean;
   iosPrefersEphemeralSession?: boolean;
 };
 

--- a/packages/react-native-app-auth/index.js
+++ b/packages/react-native-app-auth/index.js
@@ -214,6 +214,7 @@ export const authorize = ({
   androidTrustedWebActivity = false,
   connectionTimeoutSeconds,
   iosPrefersEphemeralSession = false,
+  androidPrefersEphemeralSession = false
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);
@@ -243,6 +244,7 @@ export const authorize = ({
     nativeMethodArguments.push(customHeaders);
     nativeMethodArguments.push(androidAllowCustomBrowsers);
     nativeMethodArguments.push(androidTrustedWebActivity);
+    nativeMethodArguments.push(androidPrefersEphemeralSession);
   }
 
   if (Platform.OS === 'ios') {

--- a/packages/react-native-app-auth/index.js
+++ b/packages/react-native-app-auth/index.js
@@ -230,7 +230,7 @@ export const authorize = ({
   androidTrustedWebActivity = false,
   connectionTimeoutSeconds,
   iosPrefersEphemeralSession = false,
-  androidPrefersEphemeralSession = false
+  androidPrefersEphemeralSession = false,
 }) => {
   validateIssuerOrServiceConfigurationEndpoints(issuer, serviceConfiguration);
   validateClientId(clientId);

--- a/packages/react-native-app-auth/index.spec.js
+++ b/packages/react-native-app-auth/index.spec.js
@@ -69,6 +69,7 @@ describe('AppAuth', () => {
     iosPrefersEphemeralSession: true,
     androidAllowCustomBrowsers: ['chrome'],
     androidTrustedWebActivity: false,
+    androidPrefersEphemeralSession: true
   };
 
   const registerConfig = {
@@ -745,7 +746,8 @@ describe('AppAuth', () => {
             false,
             config.customHeaders,
             config.androidAllowCustomBrowsers,
-            config.androidTrustedWebActivity
+            config.androidTrustedWebActivity,
+            config.androidPrefersEphemeralSession
           );
         });
       });
@@ -769,7 +771,8 @@ describe('AppAuth', () => {
             false,
             config.customHeaders,
             config.androidAllowCustomBrowsers,
-            config.androidTrustedWebActivity
+            config.androidTrustedWebActivity,
+            config.androidPrefersEphemeralSession
           );
         });
 
@@ -791,7 +794,8 @@ describe('AppAuth', () => {
             false,
             config.customHeaders,
             config.androidAllowCustomBrowsers,
-            config.androidTrustedWebActivity
+            config.androidTrustedWebActivity,
+            config.androidPrefersEphemeralSession
           );
         });
 
@@ -813,7 +817,8 @@ describe('AppAuth', () => {
             true,
             config.customHeaders,
             config.androidAllowCustomBrowsers,
-            config.androidTrustedWebActivity
+            config.androidTrustedWebActivity,
+            config.androidPrefersEphemeralSession
           );
         });
       });
@@ -844,7 +849,8 @@ describe('AppAuth', () => {
             false,
             customHeaders,
             config.androidAllowCustomBrowsers,
-            config.androidTrustedWebActivity
+            config.androidTrustedWebActivity,
+            config.androidPrefersEphemeralSession
           );
         });
       });

--- a/packages/react-native-app-auth/index.spec.js
+++ b/packages/react-native-app-auth/index.spec.js
@@ -69,7 +69,7 @@ describe('AppAuth', () => {
     iosPrefersEphemeralSession: true,
     androidAllowCustomBrowsers: ['chrome'],
     androidTrustedWebActivity: false,
-    androidPrefersEphemeralSession: true
+    androidPrefersEphemeralSession: true,
   };
 
   const registerConfig = {


### PR DESCRIPTION
## Description

Adds Android support for `androidPrefersEphemeralSession` by using AndroidX Browser 1.9.0 and calling `setEphemeralBrowsingEnabled` when requested.

This raises Android requirements to min SDK 21+, compile SDK 36+, and AGP 8.9.1+.

## Verification

- JS/native tests, lint, package build, and demo Android build passed locally.
- AVD check confirmed `androidPrefersEphemeralSession=true` reached native Android and launched a Chrome Custom Tab.