### PR TITLE
remove public prefix

### DIFF
--- a/.changeset/calm-pumas-smile.md
+++ b/.changeset/calm-pumas-smile.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+Support Expo 55 AppDelegate declarations without the public class modifier.

--- a/packages/react-native-app-auth/plugin/src/ios/app-delegate.ts
+++ b/packages/react-native-app-auth/plugin/src/ios/app-delegate.ts
@@ -8,7 +8,7 @@ const withAppDelegateSwift: ConfigPlugin = rootConfig => {
     let { contents } = config.modResults;
 
     if (!contents.includes('RNAppAuthAuthorizationFlowManager')) {
-      const replaceText = 'public class AppDelegate: ExpoAppDelegate';
+      const replaceText = 'class AppDelegate: ExpoAppDelegate';
       contents = contents.replace(replaceText, `${replaceText}, RNAppAuthAuthorizationFlowManager`);
 
       const replaceText2 =


### PR DESCRIPTION
Adds compatibility for Expo 55

## Description

Expo does not use the public class prefix in version 55.

It should work with both new and old versions of Expo.

Fixes #1110