### PR TITLE
fix(android): added support for response mode parameter

### DIFF
--- a/.changeset/khaki-forks-unite.md
+++ b/.changeset/khaki-forks-unite.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': minor
+---
+
+Added support for passing response_mode as an additional parameter in the config.

--- a/packages/react-native-app-auth/android/src/main/java/com/rnappauth/RNAppAuthModule.java
+++ b/packages/react-native-app-auth/android/src/main/java/com/rnappauth/RNAppAuthModule.java
@@ -710,6 +710,10 @@ public class RNAppAuthModule extends ReactContextBaseJavaModule implements Activ
                 additionalParametersMap.remove("ui_locales");
 
             }
+            if (additionalParametersMap.containsKey("response_mode")) {
+                authRequestBuilder.setResponseMode(additionalParametersMap.get("response_mode"));
+                additionalParametersMap.remove("response_mode");
+            }
 
             authRequestBuilder.setAdditionalParameters(additionalParametersMap);
         }


### PR DESCRIPTION
Fixes #1112

## Description

Handled response_mode parameter in RNAppAuthModule.java

## Steps to verify

Using `response_mode` parameter in authorization request as below, should not result into an error.

```
const result = await authorize({
  // issuer, clientId, redirectUrl, scopes etc.
  additionalParameters: {
    response_mode: 'query',
  }
});
```
