### PR TITLE
fix: add missing RCTLinkingManager fallback in RN 0.77+ setup and example app

### DIFF
--- a/.changeset/rich-avocados-complain.md
+++ b/.changeset/rich-avocados-complain.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': patch
+---
+
+Add missing RCTLinkingManager fallback for non-auth urls in iOS AppDelegate setup docs and example

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -183,7 +183,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate,
         return true
       }
     }
-    return false
+    return RCTLinkingManager.application(app, open: url, options: options)
   }
 }
 ```

--- a/examples/demo/ios/Example/AppDelegate.swift
+++ b/examples/demo/ios/Example/AppDelegate.swift
@@ -53,7 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate,
         return true
       }
     }
-    return false
+    return RCTLinkingManager.application(app, open: url, options: options)
   }
 
   func application(


### PR DESCRIPTION
## Description

This PR adds the missing `RCTLinkingManager` fallback for non-auth urls in the `application(_:open:options:)` method in the iOS set-up documentation for `react-native >= 0.77` and the example app. 

<!-- Include a summary of the work -->

## Steps to verify

The fallback is present in the instructions for older `react-native` versions in the [documentation](https://nearform.com/open-source/react-native-app-auth/docs/#for-react-native--068). 

<!-- Describe steps to verify -->

<!-- Please ensure you have have updated the tests, readme, typescript definitions -->
