### PR TITLE
feat(ios): natively intercept https redirect URIs via ASWebAuthenticationSession callback (iOS 17.4+)

### DIFF
--- a/.changeset/https-callback-ios.md
+++ b/.changeset/https-callback-ios.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': minor
+---
+
+iOS: natively intercept https (universal link) redirect URIs on iOS 17.4+ using the ASWebAuthenticationSession https callback, so the authorization flow no longer depends on universal-link activation from inside the auth session — which is not triggered by server redirects and sporadically leaves authorize() pending forever (#987, #932).

--- a/.changeset/https-callback-ios.md
+++ b/.changeset/https-callback-ios.md
@@ -1,5 +1,0 @@
----
-'react-native-app-auth': minor
----
-
-iOS: natively intercept https (universal link) redirect URIs on iOS 17.4+ using the ASWebAuthenticationSession https callback, so the authorization flow no longer depends on universal-link activation from inside the auth session — which is not triggered by server redirects and sporadically leaves authorize() pending forever (#987, #932).

--- a/.changeset/https-callback-ios.md
+++ b/.changeset/https-callback-ios.md
@@ -2,4 +2,4 @@
 'react-native-app-auth': minor
 ---
 
-iOS: natively intercept https (universal link) redirect URIs on iOS 17.4+ using the ASWebAuthenticationSession https callback, so the authorization flow no longer depends on universal-link activation from inside the auth session (which is not triggered by server redirects and sporadically leaves authorize() pending forever).
+iOS: natively intercept https (universal link) redirect URIs on iOS 17.4+ using the ASWebAuthenticationSession https callback, so the authorization flow no longer depends on universal-link activation from inside the auth session — which is not triggered by server redirects and sporadically leaves authorize() pending forever (#987, #932).

--- a/.changeset/https-callback-ios.md
+++ b/.changeset/https-callback-ios.md
@@ -1,0 +1,5 @@
+---
+'react-native-app-auth': minor
+---
+
+iOS: natively intercept https (universal link) redirect URIs on iOS 17.4+ using the ASWebAuthenticationSession https callback, so the authorization flow no longer depends on universal-link activation from inside the auth session (which is not triggered by server redirects and sporadically leaves authorize() pending forever).

--- a/packages/react-native-app-auth/ios/RNAppAuth.m
+++ b/packages/react-native-app-auth/ios/RNAppAuth.m
@@ -12,8 +12,8 @@
 /**
  * External user agent that uses the iOS 17.4+ ASWebAuthenticationSession https callback
  * (ASWebAuthenticationSessionCallback callbackWithHTTPSHost:path:). With an https
- * (universal link) redirect URI, AppAuth-iOS passes "https" as the callbackURLScheme —
- * which ASWebAuthenticationSession does not support — so the session never intercepts
+ * (universal link) redirect URI, AppAuth-iOS passes "https" as the callbackURLScheme -
+ * which ASWebAuthenticationSession does not support - so the session never intercepts
  * the redirect and the flow has to rely on the universal link opening the app, which is
  * not triggered by server redirects/JS navigation inside the session and is sporadically
  * dropped, leaving authorize() pending forever (#987, #932; openid/AppAuth-iOS#367).
@@ -22,7 +22,7 @@
  * Requires the callback host to be an associated domain with the webcredentials service
  * type (entitlement + apple-app-site-association). When the association is missing the
  * agent transparently falls back to the legacy callbackURLScheme session, preserving
- * AppAuth's default behavior.
+ * AppAuth default behavior.
  */
 API_AVAILABLE(ios(17.4))
 @interface RNAppAuthHTTPSExternalUserAgent : NSObject <OIDExternalUserAgent, ASWebAuthenticationPresentationContextProviding>
@@ -845,8 +845,8 @@ RCT_REMAP_METHOD(logout,
 @end
 
 /**
- * Implementation modeled on AppAuth's OIDExternalUserAgentIOS, but built with
- * [ASWebAuthenticationSessionCallback callbackWithHTTPSHost:path:] so the session
+ * Implementation modeled on AppAuth's OIDExternalUserAgentIOS, but built
+ * with [ASWebAuthenticationSessionCallback callbackWithHTTPSHost:path:] so the session
  * intercepts the https redirect itself (iOS 17.4+).
  */
 @implementation RNAppAuthHTTPSExternalUserAgent {
@@ -923,10 +923,13 @@ RCT_REMAP_METHOD(logout,
             [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
             return;
         }
-        BOOL isUserCancel = [error.domain isEqualToString:ASWebAuthenticationSessionErrorDomain] &&
-            error.code == ASWebAuthenticationSessionErrorCodeCanceledLogin;
-        if (useHTTPSCallback && !isUserCancel && [strongSelf startLegacyFallbackSession]) {
-            // Missing/unvalidated webcredentials association — legacy session took over
+        // A missing webcredentials association is reported with the SAME error code as a
+        // user cancellation (ASWebAuthenticationSessionErrorCodeCanceledLogin) — but it
+        // carries an NSLocalizedFailureReason ("...requires Associated Domains using the
+        // `webcredentials` service type..."), which genuine user cancellations do not.
+        NSString *failureReason = error.userInfo[NSLocalizedFailureReasonErrorKey];
+        if (useHTTPSCallback && failureReason.length > 0 && [strongSelf startLegacyFallbackSession]) {
+            // Association missing/unvalidated — legacy session took over
             return;
         }
         NSError *safariError =

--- a/packages/react-native-app-auth/ios/RNAppAuth.m
+++ b/packages/react-native-app-auth/ios/RNAppAuth.m
@@ -7,6 +7,27 @@
 #import <React/RCTLog.h>
 #import <React/RCTConvert.h>
 #import "RNAppAuthAuthorizationFlowManager.h"
+#import <AuthenticationServices/AuthenticationServices.h>
+
+/**
+ * External user agent that uses the iOS 17.4+ ASWebAuthenticationSession https callback
+ * (ASWebAuthenticationSessionCallback callbackWithHTTPSHost:path:). With an https
+ * (universal link) redirect URI, AppAuth-iOS passes "https" as the callbackURLScheme —
+ * which ASWebAuthenticationSession does not support — so the session never intercepts
+ * the redirect and the flow has to rely on the universal link opening the app, which is
+ * not triggered by server redirects/JS navigation inside the session and is sporadically
+ * dropped, leaving authorize() pending forever (#987, #932; openid/AppAuth-iOS#367).
+ * This agent lets the session intercept the https redirect natively.
+ */
+API_AVAILABLE(ios(17.4))
+@interface RNAppAuthHTTPSExternalUserAgent : NSObject <OIDExternalUserAgent, ASWebAuthenticationPresentationContextProviding>
+
+- (nonnull instancetype)initWithPresentingViewController:(nonnull UIViewController *)presentingViewController
+                                 prefersEphemeralSession:(BOOL)prefersEphemeralSession
+                                                    host:(nonnull NSString *)host
+                                                    path:(nonnull NSString *)path;
+
+@end
 
 @interface RNAppAuth()<RNAppAuthAuthorizationFlowManagerDelegate> {
     id<OIDExternalUserAgentSession> _currentSession;
@@ -380,6 +401,20 @@ RCT_REMAP_METHOD(logout,
     id<OIDExternalUserAgent> externalUserAgent = nil;
 #elif TARGET_OS_IOS
     id<OIDExternalUserAgent> externalUserAgent = iosCustomBrowser != nil ? [self getCustomBrowser: iosCustomBrowser] : nil;
+    // Prefer the native https-callback session for https (universal link) redirect URIs
+    // (see RNAppAuthHTTPSExternalUserAgent above). Falls back to default behavior pre-17.4.
+    if (externalUserAgent == nil) {
+        if (@available(iOS 17.4, *)) {
+            NSURL *httpsRedirectURL = [NSURL URLWithString:redirectUrl];
+            if ([httpsRedirectURL.scheme isEqualToString:@"https"] && httpsRedirectURL.host != nil) {
+                externalUserAgent = [[RNAppAuthHTTPSExternalUserAgent alloc]
+                    initWithPresentingViewController:presentingViewController
+                             prefersEphemeralSession:prefersEphemeralSession
+                                                host:httpsRedirectURL.host
+                                                path:httpsRedirectURL.path.length > 0 ? httpsRedirectURL.path : @"/"];
+            }
+        }
+    }
 #endif
     
     OIDAuthorizationCallback callback = ^(OIDAuthorizationResponse *_Nullable authorizationResponse, NSError *_Nullable error) {
@@ -800,6 +835,96 @@ RCT_REMAP_METHOD(logout,
     externalUserAgent = [[OIDExternalUserAgentMac alloc] init];
   #endif
   return externalUserAgent;
+}
+
+@end
+
+/**
+ * Implementation modeled on AppAuth's OIDExternalUserAgentIOS, but built with
+ * [ASWebAuthenticationSessionCallback callbackWithHTTPSHost:path:] so the session
+ * intercepts the https redirect itself (iOS 17.4+).
+ */
+@implementation RNAppAuthHTTPSExternalUserAgent {
+    UIViewController *_presentingViewController;
+    BOOL _prefersEphemeralSession;
+    NSString *_host;
+    NSString *_path;
+    BOOL _externalUserAgentFlowInProgress;
+    __weak id<OIDExternalUserAgentSession> _session;
+    ASWebAuthenticationSession *_webAuthenticationSession;
+}
+
+- (instancetype)initWithPresentingViewController:(UIViewController *)presentingViewController
+                         prefersEphemeralSession:(BOOL)prefersEphemeralSession
+                                            host:(NSString *)host
+                                            path:(NSString *)path {
+    self = [super init];
+    if (self) {
+        _presentingViewController = presentingViewController;
+        _prefersEphemeralSession = prefersEphemeralSession;
+        _host = [host copy];
+        _path = [path copy];
+    }
+    return self;
+}
+
+- (BOOL)presentExternalUserAgentRequest:(id<OIDExternalUserAgentRequest>)request
+                                session:(id<OIDExternalUserAgentSession>)session {
+    if (_externalUserAgentFlowInProgress) {
+        return NO;
+    }
+    _externalUserAgentFlowInProgress = YES;
+    _session = session;
+
+    NSURL *requestURL = [request externalUserAgentRequestURL];
+    __weak typeof(self) weakSelf = self;
+
+    ASWebAuthenticationSessionCallback *callback =
+        [ASWebAuthenticationSessionCallback callbackWithHTTPSHost:_host path:_path];
+    ASWebAuthenticationSession *webAuthenticationSession =
+        [[ASWebAuthenticationSession alloc] initWithURL:requestURL
+                                               callback:callback
+                                      completionHandler:^(NSURL *_Nullable callbackURL, NSError *_Nullable error) {
+        typeof(self) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        strongSelf->_webAuthenticationSession = nil;
+        if (callbackURL) {
+            [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
+        } else {
+            NSError *safariError =
+                [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
+                                 underlyingError:error
+                                     description:nil];
+            [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
+        }
+    }];
+
+    webAuthenticationSession.presentationContextProvider = self;
+    webAuthenticationSession.prefersEphemeralWebBrowserSession = _prefersEphemeralSession;
+    _webAuthenticationSession = webAuthenticationSession;
+    return [webAuthenticationSession start];
+}
+
+- (void)dismissExternalUserAgentAnimated:(BOOL)animated completion:(nonnull void (^)(void))completion {
+    if (!_externalUserAgentFlowInProgress) {
+        if (completion) {
+            completion();
+        }
+        return;
+    }
+    _externalUserAgentFlowInProgress = NO;
+    [_webAuthenticationSession cancel];
+    _webAuthenticationSession = nil;
+    _session = nil;
+    if (completion) {
+        completion();
+    }
+}
+
+- (ASPresentationAnchor)presentationAnchorForWebAuthenticationSession:(ASWebAuthenticationSession *)session {
+    return _presentingViewController.view.window;
 }
 
 @end

--- a/packages/react-native-app-auth/ios/RNAppAuth.m
+++ b/packages/react-native-app-auth/ios/RNAppAuth.m
@@ -18,6 +18,11 @@
  * not triggered by server redirects/JS navigation inside the session and is sporadically
  * dropped, leaving authorize() pending forever (#987, #932; openid/AppAuth-iOS#367).
  * This agent lets the session intercept the https redirect natively.
+ *
+ * Requires the callback host to be an associated domain with the webcredentials service
+ * type (entitlement + apple-app-site-association). When the association is missing the
+ * agent transparently falls back to the legacy callbackURLScheme session, preserving
+ * AppAuth's default behavior.
  */
 API_AVAILABLE(ios(17.4))
 @interface RNAppAuthHTTPSExternalUserAgent : NSObject <OIDExternalUserAgent, ASWebAuthenticationPresentationContextProviding>
@@ -850,8 +855,10 @@ RCT_REMAP_METHOD(logout,
     NSString *_host;
     NSString *_path;
     BOOL _externalUserAgentFlowInProgress;
+    BOOL _didFallBackToLegacySession;
     __weak id<OIDExternalUserAgentSession> _session;
     ASWebAuthenticationSession *_webAuthenticationSession;
+    NSURL *_requestURL;
 }
 
 - (instancetype)initWithPresentingViewController:(UIViewController *)presentingViewController
@@ -875,16 +882,38 @@ RCT_REMAP_METHOD(logout,
     }
     _externalUserAgentFlowInProgress = YES;
     _session = session;
+    _requestURL = [request externalUserAgentRequestURL];
 
-    NSURL *requestURL = [request externalUserAgentRequestURL];
+    ASWebAuthenticationSession *webAuthenticationSession = [self authenticationSessionWithHTTPSCallback:YES];
+    _webAuthenticationSession = webAuthenticationSession;
+    if ([webAuthenticationSession start]) {
+        return YES;
+    }
+    return [self startLegacyFallbackSession];
+}
+
+/**
+ * The https callback requires the callback host to be an associated domain with the
+ * webcredentials service type (entitlement + apple-app-site-association entry). When the
+ * association is missing or not yet validated, the session refuses to start — either
+ * start returns NO or the completion handler fires immediately with a non-cancel error.
+ * In both cases fall back to the legacy callbackURLScheme session, which matches
+ * AppAuth's default behavior, so sign-in keeps working instead of hard-failing.
+ */
+- (BOOL)startLegacyFallbackSession {
+    if (_didFallBackToLegacySession) {
+        return NO;
+    }
+    _didFallBackToLegacySession = YES;
+    ASWebAuthenticationSession *fallbackSession = [self authenticationSessionWithHTTPSCallback:NO];
+    _webAuthenticationSession = fallbackSession;
+    return [fallbackSession start];
+}
+
+- (ASWebAuthenticationSession *)authenticationSessionWithHTTPSCallback:(BOOL)useHTTPSCallback {
     __weak typeof(self) weakSelf = self;
-
-    ASWebAuthenticationSessionCallback *callback =
-        [ASWebAuthenticationSessionCallback callbackWithHTTPSHost:_host path:_path];
-    ASWebAuthenticationSession *webAuthenticationSession =
-        [[ASWebAuthenticationSession alloc] initWithURL:requestURL
-                                               callback:callback
-                                      completionHandler:^(NSURL *_Nullable callbackURL, NSError *_Nullable error) {
+    void (^completionHandler)(NSURL *_Nullable, NSError *_Nullable) =
+        ^(NSURL *_Nullable callbackURL, NSError *_Nullable error) {
         typeof(self) strongSelf = weakSelf;
         if (!strongSelf) {
             return;
@@ -892,19 +921,37 @@ RCT_REMAP_METHOD(logout,
         strongSelf->_webAuthenticationSession = nil;
         if (callbackURL) {
             [strongSelf->_session resumeExternalUserAgentFlowWithURL:callbackURL];
-        } else {
-            NSError *safariError =
-                [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
-                                 underlyingError:error
-                                     description:nil];
-            [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
+            return;
         }
-    }];
+        BOOL isUserCancel = [error.domain isEqualToString:ASWebAuthenticationSessionErrorDomain] &&
+            error.code == ASWebAuthenticationSessionErrorCodeCanceledLogin;
+        if (useHTTPSCallback && !isUserCancel && [strongSelf startLegacyFallbackSession]) {
+            // Missing/unvalidated webcredentials association — legacy session took over
+            return;
+        }
+        NSError *safariError =
+            [OIDErrorUtilities errorWithCode:OIDErrorCodeUserCanceledAuthorizationFlow
+                             underlyingError:error
+                                 description:nil];
+        [strongSelf->_session failExternalUserAgentFlowWithError:safariError];
+    };
 
-    webAuthenticationSession.presentationContextProvider = self;
-    webAuthenticationSession.prefersEphemeralWebBrowserSession = _prefersEphemeralSession;
-    _webAuthenticationSession = webAuthenticationSession;
-    return [webAuthenticationSession start];
+    ASWebAuthenticationSession *session;
+    if (useHTTPSCallback) {
+        ASWebAuthenticationSessionCallback *callback =
+            [ASWebAuthenticationSessionCallback callbackWithHTTPSHost:_host path:_path];
+        session = [[ASWebAuthenticationSession alloc] initWithURL:_requestURL
+                                                         callback:callback
+                                                completionHandler:completionHandler];
+    } else {
+        // Matches AppAuth's OIDExternalUserAgentIOS default for https redirect URIs
+        session = [[ASWebAuthenticationSession alloc] initWithURL:_requestURL
+                                                callbackURLScheme:@"https"
+                                                completionHandler:completionHandler];
+    }
+    session.presentationContextProvider = self;
+    session.prefersEphemeralWebBrowserSession = _prefersEphemeralSession;
+    return session;
 }
 
 - (void)dismissExternalUserAgentAnimated:(BOOL)animated completion:(nonnull void (^)(void))completion {


### PR DESCRIPTION
Fixes #987

## Description

When the redirect URI is an https universal link, `OIDExternalUserAgentIOS` creates the session with `callbackURLScheme:@"https"` — a scheme `ASWebAuthenticationSession` does not support — so the session never intercepts the redirect. Flow completion then depends on the universal link opening the app from *inside* the auth session, which is not triggered by server-side redirects or JS navigation, and is sporadically dropped entirely. The result is an `authorize()` promise that never settles, with the user stuck on a permanently disabled login UI (also reported as #932; root cause tracked upstream since 2018 in openid/AppAuth-iOS#367, and the `callbackURLScheme:` initializer is deprecated per openid/AppAuth-iOS#847). The same failure class affects other SDKs (e.g. google/GoogleSignIn-iOS#388). The common workaround — a hosted "trampoline" page forwarding the callback to a custom scheme — reintroduces the custom scheme universal links were adopted to avoid, and the in-session JS hop is itself sporadically blocked by WebKit.

iOS 17.4 added `ASWebAuthenticationSessionCallback callbackWithHTTPSHost:path:`, which lets the session intercept an https redirect natively — no app-site-association timing dependency, no trampoline page, no custom scheme.

This PR adds `RNAppAuthHTTPSExternalUserAgent` (modeled on AppAuth's `OIDExternalUserAgentIOS`, including ephemeral-session and presentation-context handling) and uses it automatically when:

- no `iosCustomBrowser` is requested, and
- the redirect URI scheme is `https`, and
- running on iOS 17.4+.

Everything else — custom browsers, custom-scheme redirect URIs, iOS < 17.4 — keeps the existing behavior, so this is a progressive enhancement with no API surface change.

Notes per CONTRIBUTING:
- iOS-only by design: Android already supports https App Links redirects natively through AppAuth-Android's `RedirectUriReceiverActivity` intent filters, so there is no equivalent defect to replicate there.
- No JS/TypeScript surface change → no `index.js`/`index.spec.js`/typings/readme updates needed; `yarn test` and `yarn lint` are unaffected (native-only change).
- Changeset included (`minor`).

## Steps to verify

**Requirement:** the https callback path needs the callback host registered as an associated domain with the **webcredentials** service type — both the `com.apple.developer.associated-domains` entitlement (`webcredentials:example.com`) and a `webcredentials` entry for the app in the domain's `apple-app-site-association` file. Without the association, the agent transparently falls back to the legacy `callbackURLScheme` session (AppAuth's default behavior), so apps without the association are unaffected.

1. Configure an OIDC provider with an **https universal-link** redirect URI, add the `webcredentials` associated domain (entitlement + AASA), and run on an iOS 17.4+ device or simulator.
2. Call `authorize()` and complete sign-in: the session intercepts the redirect itself — the sheet closes on the provider's 302 without loading the redirect page, and `authorize()` resolves with the token response.
3. Cancel the sheet: `authorize()` rejects with the user-cancelled error as before.
4. Remove the `webcredentials` association and repeat: the fallback path engages and behavior matches current `main`.
5. Run on iOS < 17.4 (or with `iosCustomBrowser`, or a custom-scheme redirect URI): behavior is unchanged from current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
